### PR TITLE
tools: add support for Espressif driver

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -60,6 +60,25 @@ function PrepareIdfPackage {
     Remove-Item -Path $FullDistZipPath
 }
 
+function PrepareIdfFile {
+    param (
+        [Parameter()]
+        [String]
+        $BasePath,
+        [String]
+        $FilePath,
+        [String]
+        $DownloadUrl
+    )
+    $FullFilePath = Join-Path -Path $BasePath -ChildPath $FilePath
+    if (Test-Path -Path $FullFilePath -PathType Leaf) {
+        "$FullFilePath found."
+        return
+    }
+
+    Invoke-WebRequest -O $FullFilePath $DownloadUrl
+}
+
 function PrepareIdfCmdlinerunner {
     PrepareIdfPackage -BasePath build\$InstallerType\lib `
         -FilePath cmdlinerunner.dll `
@@ -75,10 +94,9 @@ function PrepareIdf7za {
 }
 
 function PrepareIdfEnv {
-    PrepareIdfPackage -BasePath build\$InstallerType\lib `
+    PrepareIdfFile -BasePath build\$InstallerType\lib `
         -FilePath idf-env.exe `
-        -DistZip idf-env.zip `
-        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.0.0/idf-env.zip
+        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.1.0/idf-env.exe
 }
 
 function PrepareIdfGit {

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -5,7 +5,7 @@
 #include <idp.iss>
 
 #define MyAppName "ESP-IDF Tools"
-#define MyAppVersion "2.7"
+#define MyAppVersion "2.8"
 #define MyAppPublisher "Espressif Systems (Shanghai) Co. Ltd."
 #define MyAppURL "https://github.com/espressif/esp-idf"
 
@@ -90,6 +90,7 @@
 #define COMPONENT_DRIVER = "driver"
 #define COMPONENT_DRIVER_FTDI = "driver/ftdi"
 #define COMPONENT_DRIVER_SILABS = "driver/silabs"
+#define COMPONENT_DRIVER_ESPRESSIF = "driver/espressif"
 #define COMPONENT_OPTIMIZATION = 'optimization'
 #define COMPONENT_OPTIMIZATION_ESPRESSIF_DOWNLOAD = 'optimization/espressif_download'
 
@@ -182,6 +183,7 @@ Name: "{#COMPONENT_CMD}"; Description: "Command Prompt"; Types: full; Flags: che
 Name: "{#COMPONENT_CMD_DESKTOP}"; Description: "Desktop shortcut"; Types: full
 Name: "{#COMPONENT_CMD_STARTMENU}"; Description: "Start Menu shortcut"; Types: full
 Name: "{#COMPONENT_DRIVER}"; Description: "Drivers - Requires elevation of privileges"; Types: full; Flags: checkablealone
+Name: "{#COMPONENT_DRIVER_ESPRESSIF}"; Description: "Espressif - WinUSB support for JTAG (ESP32-C3)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_DRIVER_FTDI}"; Description: "FTDI Chip - Virtual COM Port for USB (WROVER, WROOM)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_DRIVER_SILABS}"; Description: "Silicon Labs - Virtual COM Port for USB CP210x (ESP boards)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_OPTIMIZATION}"; Description: "Optimization"; Flags: fixed

--- a/src/InnoSetup/PreInstall.iss
+++ b/src/InnoSetup/PreInstall.iss
@@ -138,6 +138,10 @@ begin
     DriverList := DriverList + ' --silabs'
   end;
 
+  if (WizardIsComponentSelected('{#COMPONENT_DRIVER_ESPRESSIF}')) then begin
+    DriverList := DriverList + ' --espressif'
+  end;
+
   if (Length(DriverList) > 0) then begin
     InstallDrivers(DriverList);
   end;


### PR DESCRIPTION
Added checkbox for option to install Espressif driver for ESP32-C3 JTAG support.