### PR TITLE
Hide extra logs during upload to s3

### DIFF
--- a/.github/workflows/build-offline-installer.yml
+++ b/.github/workflows/build-offline-installer.yml
@@ -56,4 +56,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         shell: pwsh
-        run: aws s3 cp --acl=public-read ./build/esp-idf-tools-setup-offline-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/esp-idf-tools-setup-${{ steps.get_version.outputs.VERSION }}.exe
+        run: aws s3 cp --acl=public-read --no-progress ./build/esp-idf-tools-setup-offline-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/esp-idf-tools-setup-${{ steps.get_version.outputs.VERSION }}.exe

--- a/.github/workflows/build-online-installer.yml
+++ b/.github/workflows/build-online-installer.yml
@@ -56,4 +56,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         shell: pwsh
-        run: aws s3 cp --acl=public-read ./build/esp-idf-tools-setup-online-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/esp-idf-tools-setup-${{ steps.get_version.outputs.VERSION }}.exe
+        run: aws s3 cp --acl=public-read --no-progress ./build/esp-idf-tools-setup-online-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/esp-idf-tools-setup-${{ steps.get_version.outputs.VERSION }}.exe


### PR DESCRIPTION
With `--no-progress` flag errors are still printed but verbose output of uploading progress is hidden