### PR TITLE
tools: display error in case of ESP-IDF path longer than 90 characters

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -5,7 +5,7 @@
 #include <idp.iss>
 
 #define MyAppName "ESP-IDF Tools"
-#define MyAppVersion "2.8"
+#define MyAppVersion "2.9"
 #define MyAppPublisher "Espressif Systems (Shanghai) Co. Ltd."
 #define MyAppURL "https://github.com/espressif/esp-idf"
 

--- a/src/InnoSetup/Languages/IdfToolsSetup_en-US.islu
+++ b/src/InnoSetup/Languages/IdfToolsSetup_en-US.islu
@@ -48,3 +48,4 @@ CreateShortcutCMD=CMD - Create shortcut for the ESP-IDF Tools:
 OptimizationTitle=Optimization:
 OptimizationWindowsDefender=Register the ESP-IDF Tools executables as Windows Defender exclusions. The registration might improve compilation time by about 30%. The installer deployed the files on the operating system and antivirus software scanned them. The registration of exclusions requires the elevation of privileges. The exclusions can be added/removed by idf-env tool. More details: https://github.com/espressif/idf-env.
 OptimizationDownloadMirror=Use Espressif download server instead of downloading tool packages from GitHub.
+ErrorTooLongIdfPath=Length of the path to ESP-IDF exceeds 90 characters. Too long path might cause problem to some build tools. Please choose shorter path.

--- a/src/InnoSetup/Languages/IdfToolsSetup_en-US.islu
+++ b/src/InnoSetup/Languages/IdfToolsSetup_en-US.islu
@@ -49,3 +49,4 @@ OptimizationTitle=Optimization:
 OptimizationWindowsDefender=Register the ESP-IDF Tools executables as Windows Defender exclusions. The registration might improve compilation time by about 30%. The installer deployed the files on the operating system and antivirus software scanned them. The registration of exclusions requires the elevation of privileges. The exclusions can be added/removed by idf-env tool. More details: https://github.com/espressif/idf-env.
 OptimizationDownloadMirror=Use Espressif download server instead of downloading tool packages from GitHub.
 ErrorTooLongIdfPath=Length of the path to ESP-IDF exceeds 90 characters. Too long path might cause problem to some build tools. Please choose shorter path.
+ErrorTooLongToolsPath=Length of the path to ESP-IDF Tools exceeds 90 characters. Too long path might cause problem to some build tools. Please choose shorter path.

--- a/src/InnoSetup/Pages/IdfDownloadPage.iss
+++ b/src/InnoSetup/Pages/IdfDownloadPage.iss
@@ -150,6 +150,12 @@ begin
     exit;
   end;
 
+  if (Length(IDFPath) > 90) then begin
+    MessageBox(CustomMessage('ErrorTooLongIdfPath'), mbError, MB_OK);
+    Result := False;
+    exit;
+  end;
+
   IDFDownloadPath := IDFPath;
 
   { Use parameter /IDFVERSION=x to override selection in the box. }

--- a/src/InnoSetup/Pages/IdfPage.iss
+++ b/src/InnoSetup/Pages/IdfPage.iss
@@ -90,6 +90,12 @@ begin
       exit;
     end;
 
+    if (Length(IDFPath) > 90) then begin
+      MessageBox(CustomMessage('ErrorTooLongIdfPath'), mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+
     IDFPyPath := IDFPath + '\tools\idf.py';
     if not FileExists(IDFPyPath) then
     begin
@@ -149,6 +155,13 @@ begin
   if CurPageID = wpSelectDir then
   begin
     ToolsDir := WizardForm.DirEdit.Text;
+
+    if (Length(ToolsDir) > 90) then begin
+      MessageBox(CustomMessage('ErrorTooLongToolsPath'), mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+
     IDFDir := GetIDFPath('');
     Log('Checking location of ToolsDir ' + ToolsDir + ' is not a subdirectory of ' + IDFDir);
     if Pos(IDFDir, ToolsDir) = 1 then


### PR DESCRIPTION
Too long path causes problem in CCache which causes issues like: https://esp32.com/viewtopic.php?f=25&p=67838&sid=d3c6aafbf9c52edf255e1d97273c1de8#p67838