### PR TITLE
tools: add checkbox with PowerShell and CMD launcher

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -192,7 +192,6 @@ Name: "{#COMPONENT_OPTIMIZATION_ESPRESSIF_DOWNLOAD}"; Description: "Use Espressi
 ;Name: "optimization\windowsdefender"; Description: "Register Windows Defender exceptions"; Types: full
 
 
-;Name: "ide\eclipse\openjdk"; Description: "OpenJDK"; Types: full
 ;Name: "idf"; Description: "ESP-IDF"; Types: full
 ;Name: "idf\tools"; Description: "Chip"; Types: full
 ;Name: "idf\tools\chip_esp32"; Description: "ESP32"; Types: full
@@ -225,11 +224,9 @@ Type: filesandordirs; Name: "{app}\python_env"
 [Run]
 Filename: "{app}\dist\{#GitInstallerName}"; Parameters: "/silent /tasks="""" /norestart"; Description: "Installing Git"; Check: GitInstallRequired
 Filename: "{autodesktop}\{#IDFEclipseShortcutFile}"; Flags: runascurrentuser postinstall shellexec unchecked; Description: "Run ESP-IDF Eclipse Environment"; Components: "{#COMPONENT_ECLIPSE_DESKTOP}"
-;Filename: "{autodesktop}\{#IDFPsShortcutFile}"; Flags: postinstall shellexec unchecked; Description: "Run ESP-IDF PowerShell Environment"; Components: "{#COMPONENT_POWERSHELL_DESKTOP}"
-;Filename: "{autodesktop}\{#IDFCmdExeShortcutFile}"; Flags: postinstall shellexec unchecked; Description: "Run ESP-IDF Command Prompt Environment"; Components: "{#COMPONENT_CMD_DESKTOP}"
+Filename: "{code:GetLauncherPathPowerShell}"; Flags: postinstall shellexec; Description: "Run ESP-IDF PowerShell Environment"; Components: "{#COMPONENT_POWERSHELL_DESKTOP} {#COMPONENT_CMD_STARTMENU}"
+Filename: "{code:GetLauncherPathCMD}"; Flags: postinstall shellexec; Description: "Run ESP-IDF Command Prompt Environment"; Components: "{#COMPONENT_CMD_DESKTOP} {#COMPONENT_CMD_STARTMENU}";
 
-;Filename: "{group}\{#IDFPsShortcutFile}"; Flags: postinstall shellexec unchecked; Description: "Run ESP-IDF PowerShell Environment"; Check: IsPowerShellInstalled
-;Filename: "{group}\{#IDFCmdExeShortcutFile}"; Flags: postinstall shellexec unchecked; Description: "Run ESP-IDF Command Prompt Environment"; Check: IsCmdInstalled
 ; WD registration checkbox is identified by 'Windows Defender' substring anywhere in its caption, not by the position index in WizardForm.TasksList.Items
 ; Please, keep this in mind when making changes to the item's description - WD checkbox is to be disabled on systems without the Windows Defender installed
 Filename: "{app}\idf-env.exe"; Parameters: "antivirus exclusion add --all"; Flags: postinstall shellexec runhidden; Description: "{cm:OptimizationWindowsDefender}"; Check: GetIsWindowsDefenderEnabled

--- a/src/InnoSetup/Pages/IdfPage.iss
+++ b/src/InnoSetup/Pages/IdfPage.iss
@@ -149,7 +149,6 @@ function ToolsLocationPageValidate(CurPageID: Integer): Boolean;
 var
   ToolsDir: String;
   IDFDir: String;
-  Msg: string;
 begin
   Result := True;
   if CurPageID = wpSelectDir then

--- a/src/InnoSetup/PostInstall.iss
+++ b/src/InnoSetup/PostInstall.iss
@@ -3,6 +3,23 @@
   SPDX-License-Identifier: Apache-2.0 }
 
 { ------------------------------ Start menu shortcut ------------------------------ }
+
+{ Store launcher paths so they can be invoked in post install phase declared in Run section. }
+var LauncherPathPowerShell: String;
+var LauncherPathCMD: String;
+
+{ Helper function to retrieve value from variable in Run section. }
+function GetLauncherPathPowerShell(Param: String):String;
+begin
+  Result := LauncherPathPowerShell;
+end;
+
+{ Helper function to retrieve value from variable in Run section. }
+function GetLauncherPathCMD(Param: String):String;
+begin
+  Result := LauncherPathCMD;
+end;
+
 { Get suffix of the text for link so that user can see multiple IDF installed. }
 function GetLinkDestination(LinkString: String; Title: String): String;
 begin
@@ -11,54 +28,52 @@ end;
 
 procedure CreateIDFCommandPromptShortcut(LinkString: String);
 var
-  Destination: String;
   Description: String;
   Command: String;
 begin
   ForceDirectories(ExpandConstant(LinkString));
-  Destination := GetLinkDestination(LinkString, 'CMD');
+  LauncherPathCMD := GetLinkDestination(LinkString, 'CMD');
   Description := '{#IDFCmdExeShortcutDescription}';
 
   { If cmd.exe command argument starts with a quote, the first and last quote chars in the command
     will be removed by cmd.exe; each argument needs to be surrounded by quotes as well. }
   Command := '/k ""' + ExpandConstant('{app}\idf_cmd_init.bat') + '"';
-  Log('CreateShellLink Destination=' + Destination + ' Description=' + Description + ' Command=' + Command)
+  Log('CreateShellLink Destination=' + LauncherPathCMD + ' Description=' + Description + ' Command=' + Command)
   try
     CreateShellLink(
-      Destination,
+      LauncherPathCMD,
       Description,
       'cmd.exe',
       Command,
       GetIDFPath(''),
       '', 0, SW_SHOWNORMAL);
   except
-    MessageBox('Failed to create the shortcut: ' + Destination, mbError, MB_OK);
+    MessageBox('Failed to create the shortcut: ' + LauncherPathCMD, mbError, MB_OK);
     RaiseException('Failed to create the shortcut');
   end;
 end;
 
 procedure CreateIDFPowershellShortcut(LinkString: String);
 var
-  Destination: String;
   Description: String;
   Command: String;
 begin
   ForceDirectories(ExpandConstant(LinkString));
-  Destination := GetLinkDestination(LinkString, 'PowerShell');
+  LauncherPathPowerShell := GetLinkDestination(LinkString, 'PowerShell');
   Description := '{#IDFPsShortcutDescription}';
 
   Command := ExpandConstant('-ExecutionPolicy Bypass -NoExit -File "{app}/Initialize-Idf.ps1"');
-  Log('CreateShellLink Destination=' + Destination + ' Description=' + Description + ' Command=' + Command)
+  Log('CreateShellLink Destination=' + LauncherPathPowerShell + ' Description=' + Description + ' Command=' + Command)
   try
     CreateShellLink(
-      Destination,
+      LauncherPathPowerShell,
       Description,
       'powershell.exe',
       Command,
       GetIDFPath(''),
       '', 0, SW_SHOWNORMAL);
   except
-    MessageBox('Failed to create the shortcut: ' + Destination, mbError, MB_OK);
+    MessageBox('Failed to create the shortcut: ' + LauncherPathPowerShell, mbError, MB_OK);
     RaiseException('Failed to create the shortcut');
   end;
 end;


### PR DESCRIPTION
Display checkboxes at the end of installation process: PowerShell and CMD launchers.
Checkbox is visible only when launcher component was selected in Component selection section.