### PR TITLE
tools: support for launching ESP-IDF from different directory

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -96,7 +96,7 @@ function PrepareIdf7za {
 function PrepareIdfEnv {
     PrepareIdfFile -BasePath build\$InstallerType\lib `
         -FilePath idf-env.exe `
-        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.1.8.0/win64.idf-env.exe
+        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.2.1.0/win64.idf-env.exe
 }
 
 function PrepareIdfGit {

--- a/src/Batch/idf_cmd_init.bat
+++ b/src/Batch/idf_cmd_init.bat
@@ -1,12 +1,12 @@
 @echo off
 
-:: This script is called from a shortcut (cmd.exe /k export_fallback.bat), with
-:: the working directory set to an ESP-IDF directory.
-:: Its purpose is to support using the "IDF Tools Directory" method of
-:: installation for ESP-IDF versions older than IDF v4.0.
-:: It does the same thing as "export.bat" in IDF v4.0.
+:: The script determines location of Git, Python and ESP-IDF.
+:: Similar result can be achieved by running export.ps1 from ESP-IDF directory.
 
-set IDF_PATH=%CD%
+:: How the script determines the location of ESP-IDF:
+:: 1. try to use the fist input parameter to query configuration managed by idf-env
+:: 2. try to use environment variable IDF_PATH to query configuration managed by idf-env
+:: 3. try to use local working directory to query configuration managed by idf-env
 
 if "%IDF_TOOLS_PATH%" == "" (
     set IDF_TOOLS_PATH=%~dp0
@@ -21,14 +21,27 @@ if exist "echo" (
 
 set PATH=%IDF_TOOLS_PATH%;%PATH%
 set TEMP_IDF_PYTHON_PATH="%TEMP%\idf-python-path.txt"
-idf-env config get --property python --idf-path %IDF_PATH%\>%TEMP_IDF_PYTHON_PATH%
-set /P IDF_PYTHON_DIR=<%TEMP_IDF_PYTHON_PATH%
+set TEMP_IDF_PATH=%TEMP%\idf-path.txt
+:: Check whether IDF ID was specified as the first parameter
+set PARAM=%1
+if /i "%PARAM:~0,7%"=="esp-idf" (
+    idf-env config get --property "path" --idf-id %PARAM%>%TEMP_IDF_PATH%
+    idf-env config get --property python --idf-id %PARAM%>%TEMP_IDF_PYTHON_PATH%
+    set /P IDF_PATH=<"%TEMP_IDF_PATH%"
+) else (
+    if "%IDF_PATH%" == "" (
+        set IDF_PATH=%CD%
+    )
+    idf-env config get --property python --idf-path %IDF_PATH%\>%TEMP_IDF_PYTHON_PATH%
+)
+
+set /P IDF_PYTHON=<%TEMP_IDF_PYTHON_PATH%
 
 set TEMP_IDF_GIT_PATH="%TEMP%\idf-git-path.txt"
 idf-env config get --property gitPath>%TEMP_IDF_GIT_PATH%
-set /P IDF_GIT_DIR=<%TEMP_IDF_GIT_PATH%
+set /P IDF_GIT=<%TEMP_IDF_GIT_PATH%
 
-set PREFIX=%IDF_PYTHON_DIR%\python.exe %IDF_PATH%
+set PREFIX=%IDF_PYTHON% %IDF_PATH%
 DOSKEY idf.py=%PREFIX%\tools\idf.py $*
 DOSKEY esptool.py=%PREFIX%\components\esptool_py\esptool\esptool.py $*
 DOSKEY espefuse.py=%PREFIX%\components\esptool_py\esptool\espefuse.py $*
@@ -53,12 +66,16 @@ if "%PYTHONNOUSERSITE%"=="" (
     set PYTHONNOUSERSITE=True
 )
 
+:: Get base name of Git and Python
+for %%F in (%IDF_PYTHON%) do set IDF_PYTHON_DIR=%%~dpF
+for %%F in (%IDF_GIT%) do set IDF_GIT_DIR=%%~dpF
+
 :: Add Python and Git paths to PATH
 set "PATH=%IDF_PYTHON_DIR%;%IDF_GIT_DIR%;%PATH%"
 echo Using Python in %IDF_PYTHON_DIR%
-python.exe --version
+%IDF_PYTHON% --version
 echo Using Git in %IDF_GIT_DIR%
-git.exe --version
+%IDF_GIT% --version
 
 :: Check if this is a recent enough copy of ESP-IDF.
 :: If so, use export.bat provided there.

--- a/src/InnoSetup/Configuration.iss
+++ b/src/InnoSetup/Configuration.iss
@@ -222,6 +222,14 @@ begin
   Result := MsgBox(Text, Typ, Buttons);
 end;
 
+function GetIdfId():String;
+var
+  IdfPathWithForwardSlashes: String;
+begin
+  IdfPathWithForwardSlashes := GetPathWithForwardSlashes(GetIDFPath(''))
+  Result := 'esp-idf-' + GetMD5OfString(IdfPathWithForwardSlashes);
+end;
+
 procedure SaveIdfEclipseConfiguration(FilePath: String);
 var
     Content: String;
@@ -230,7 +238,7 @@ var
     IdfVersion: String;
 begin
   IdfPathWithForwardSlashes := GetPathWithForwardSlashes(GetIDFPath(''))
-  IdfId := 'esp-idf-' + GetMD5OfString(IdfPathWithForwardSlashes);
+  IdfId := GetIdfId();
   IdfVersion := GetIDFVersionFromHeaderFile();
 
   Content := '{' + #13#10;

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -5,7 +5,7 @@
 #include <idp.iss>
 
 #define MyAppName "ESP-IDF Tools"
-#define MyAppVersion "2.9"
+#define MyAppVersion "2.10"
 #define MyAppPublisher "Espressif Systems (Shanghai) Co. Ltd."
 #define MyAppURL "https://github.com/espressif/esp-idf"
 
@@ -184,7 +184,7 @@ Name: "{#COMPONENT_CMD}"; Description: "Command Prompt"; Types: full; Flags: che
 Name: "{#COMPONENT_CMD_DESKTOP}"; Description: "Desktop shortcut"; Types: full
 Name: "{#COMPONENT_CMD_STARTMENU}"; Description: "Start Menu shortcut"; Types: full
 Name: "{#COMPONENT_DRIVER}"; Description: "Drivers - Requires elevation of privileges"; Types: full; Flags: checkablealone
-Name: "{#COMPONENT_DRIVER_ESPRESSIF}"; Description: "Espressif - WinUSB support for JTAG (ESP32-C3)"; Types: full; Flags: checkablealone
+Name: "{#COMPONENT_DRIVER_ESPRESSIF}"; Description: "Espressif - WinUSB support for JTAG (ESP32-C3/S3)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_DRIVER_FTDI}"; Description: "FTDI Chip - Virtual COM Port for USB (WROVER, WROOM)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_DRIVER_SILABS}"; Description: "Silicon Labs - Virtual COM Port for USB CP210x (ESP boards)"; Types: full; Flags: checkablealone
 Name: "{#COMPONENT_OPTIMIZATION}"; Description: "Optimization"; Flags: fixed

--- a/src/InnoSetup/PostInstall.iss
+++ b/src/InnoSetup/PostInstall.iss
@@ -58,7 +58,7 @@ begin
 
   { If cmd.exe command argument starts with a quote, the first and last quote chars in the command
     will be removed by cmd.exe; each argument needs to be surrounded by quotes as well. }
-  Command := '/k ""' + ExpandConstant('{app}\idf_cmd_init.bat') + '"';
+  Command := '/k ""' + ExpandConstant('{app}\idf_cmd_init.bat') + '" ' + GetIdfId() + '"';
   Log('CreateShellLink Destination=' + LauncherPathCMD + ' Description=' + Description + ' Command=' + Command)
   try
     CreateShellLink(
@@ -83,7 +83,7 @@ begin
   LauncherPathPowerShell := GetLinkDestination(LinkString, 'PowerShell');
   Description := '{#IDFPsShortcutDescription}';
 
-  Command := ExpandConstant('-ExecutionPolicy Bypass -NoExit -File "{app}/Initialize-Idf.ps1"');
+  Command := ExpandConstant('-ExecutionPolicy Bypass -NoExit -File "{app}/Initialize-Idf.ps1" -IdfId ' + GetIdfId() );
   Log('CreateShellLink Destination=' + LauncherPathPowerShell + ' Description=' + Description + ' Command=' + Command)
   try
     CreateShellLink(


### PR DESCRIPTION
Add support for launching ESP-IDF from different working directory.
It's based on esp-idf ID which is generated during installation. Instead of referencing by PATH it's referenced by the ID.
This allows to specify Working directory in LNK files.
The update contains correction for PowerShell, CMD and Windows Terminal Fragments.
The solution should be backward compatible.

Closes #31 #29