### PR TITLE
Use idf-env to update system certificates instead of PowerShell

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -96,7 +96,7 @@ function PrepareIdf7za {
 function PrepareIdfEnv {
     PrepareIdfFile -BasePath build\$InstallerType\lib `
         -FilePath idf-env.exe `
-        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.2.1.0/win64.idf-env.exe
+        -DownloadUrl https://github.com/espressif/idf-env/releases/download/v1.2.2.0/win64.idf-env.exe
 }
 
 function PrepareIdfGit {

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -5,7 +5,7 @@
 #include <idp.iss>
 
 #define MyAppName "ESP-IDF Tools"
-#define MyAppVersion "2.10"
+#define MyAppVersion "2.11"
 #define MyAppPublisher "Espressif Systems (Shanghai) Co. Ltd."
 #define MyAppURL "https://github.com/espressif/esp-idf"
 


### PR DESCRIPTION
PowerShell command is not available on all OSes. Use Rust implementation in idf-env to retrieve URL which is later on used by Python.

Closes: #5 

Mention: #50 

@JurajSadel PTAL