### PR TITLE
tools: set path to VM for Espressif-IDE in ini file

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -18,7 +18,7 @@ param (
     [String]
     $SetupCompiler = 'iscc',
     [String]
-    $IdfEnvVersion = '1.2.25',
+    $IdfEnvVersion = '1.2.26',
     [String]
     $EspressifIdeVersion = '2.4.2',
     [String]

--- a/src/InnoSetup/Eclipse.iss
+++ b/src/InnoSetup/Eclipse.iss
@@ -12,6 +12,11 @@ begin
   Result := GetEclipsePath('espressif-ide.exe');
 end;
 
+function GetEclipseIniPath():String;
+begin
+  Result := GetEclipsePath('espressif-ide.ini');
+end;
+
 procedure CreateIDFEclipseShortcut(LnkString: String);
 var
   Destination: String;

--- a/src/InnoSetup/PostInstall.iss
+++ b/src/InnoSetup/PostInstall.iss
@@ -3,9 +3,21 @@
   SPDX-License-Identifier: Apache-2.0 }
 
 procedure AppendEnvironmentVariable(VariableName: String; Value: String);
+var
+  Command: String;
 begin
-  DoCmdlineInstall(CustomMessage('SettingEnvironmentVariable'), CustomMessage('SettingEnvironmentVariable'), GetIdfEnvCommand('shell append --variable "' + VariableName + '" --path ' + Value + ' '));
+  Command := GetIdfEnvCommand('shell append --variable "' + VariableName + '" --path ' + Value + ' ')
+  DoCmdlineInstall(CustomMessage('SettingEnvironmentVariable'), CustomMessage('SettingEnvironmentVariable'), Command);
 end;
+
+procedure SetEspressifIdeVM(IniPath: String; VmPah: String);
+var
+  Command: String;
+begin
+  Command := GetIdfEnvCommand('ide configure --ini "' + IniPath + '" --vm "' + VmPah + '"')
+  DoCmdlineInstall(CustomMessage('SettingEnvironmentVariable'), CustomMessage('SettingEnvironmentVariable'), Command);
+end;
+
 
 { ------------------------------ Start menu shortcut ------------------------------ }
 
@@ -254,7 +266,7 @@ begin
     end;
 
     if (WizardIsComponentSelected('{#COMPONENT_ECLIPSE_JDK}')) then begin
-      AppendEnvironmentVariable('PATH', ExpandConstant('{app}\tools\amazon-corretto-11-x64-windows-jdk\{#JDKVERSION}\bin\'));
+      SetEspressifIdeVM(GetEclipseIniPath(), ExpandConstant('{app}\tools\amazon-corretto-11-x64-windows-jdk\{#JDKVERSION}\bin\javaw.exe'));
     end;
 
     if (WizardIsComponentSelected('{#COMPONENT_ECLIPSE_DESKTOP}')) then begin


### PR DESCRIPTION
The installer now updates espressif-ide.ini file and sets `vm` parameter. 
This solution allows to avoid conflict with System installed Java.

Closes #127 