### PR TITLE
ci: Update builds with espressif-ide v2.6.0 and esp-idf v4.4.2

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -10,7 +10,7 @@ param (
     [ValidateSet('online', 'offline', 'espressif-ide')]
     $InstallerType = 'online',
     [String]
-    $OfflineBranch = 'v4.4',
+    $OfflineBranch = 'v4.4.2',
     [String]
     $Python = 'python',
     [Boolean]
@@ -20,7 +20,7 @@ param (
     [String]
     $IdfEnvVersion = '1.2.27',
     [String]
-    $EspressifIdeVersion = '2.5.0',
+    $EspressifIdeVersion = '2.6.0',
     [String]
     $JdkVersion = "jdk11.0.15_9",
     [String]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Note: Online Installer is recommended way of the installation.
 
 | Version | Content | Size |
 | ------- | ------- | ---- |
+| Espressif-IDE v2.6.0 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.6.0/espressif-ide-setup-espressif-ide-2.6.0-with-esp-idf-4.4.2.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.6.0-with-esp-idf-4.4.2.exe) | Espressif-IDE + JDK + ESP-IDF v4.4.2 | 1 GB |
 | Espressif-IDE v2.5.0 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.5.0/espressif-ide-setup-espressif-ide-2.5.0-with-esp-idf-4.4.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.5.0-with-esp-idf-4.4.exe) | Espressif-IDE + JDK + ESP-IDF v4.4 | 1 GB |
 | Espressif-IDE v2.4.2 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.4.2/espressif-ide-setup-espressif-ide-2.4.2-with-esp-idf-4.4.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.4.2-with-esp-idf-4.4.exe) | Espressif-IDE + JDK + ESP-IDF v4.4 | 1 GB |
 | Espressif-IDE v2.4.1 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.4.1/espressif-ide-setup-espressif-ide-2.4.1-with-esp-idf-4.4.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.4.1-with-esp-idf-4.4.exe) | Espressif-IDE + JDK + ESP-IDF v4.4 | 1 GB |

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -33,7 +33,7 @@
 #define GitInstallerDownloadURL "https://dl.espressif.com/dl/idf-git/" + GitInstallerName
 
 #ifndef ESPRESSIFIDEVERSION
-  #define ESPRESSIFIDEVERSION "2.5.0"
+  #define ESPRESSIFIDEVERSION "2.6.0"
 #endif
 
 #define ECLIPSE_INSTALLER "Espressif-IDE-" + ESPRESSIFIDEVERSION + "-win32.win32.x86_64.zip"

--- a/src/Resources/download/index.html
+++ b/src/Resources/download/index.html
@@ -155,10 +155,10 @@
                 </form>
             </div>
             <div class="download-button">
-                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.5.0-with-esp-idf-4.4.exe">
+                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.6.0-with-esp-idf-4.4.2.exe">
                     <button class="button-espressif-ide">
                         <i class="fa fa-download" aria-hidden="true"></i>
-                        <div>Espressif-IDE 2.5.0 with ESP-IDF v4.4</div>
+                        <div>Espressif-IDE 2.6.0 with ESP-IDF v4.4.2</div>
                         <div>Windows 10, 11</div>
                         <div>Size: 1 GB</div>
                     </button>
@@ -316,6 +316,17 @@
                       - 4 MB</span>
                 </span>
                 <span class="release-notes"><a href="https://github.com/espressif/idf-installer/releases/tag/online-2.13">Release Notes</a></span>
+              </li>
+
+              <li>
+                <span class="release-number">Espressif-IDE 2.6.0 with ESP-IDF v4.4.2</span>
+                <span class="release-date">2022-08-12</span>
+                <span class="release-download">
+                    <span><a href="https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.6.0/espressif-ide-setup-espressif-ide-2.6.0-with-esp-idf-4.4.2.exe">Download</a> /
+                      <a href="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-espressif-ide-2.6.0-with-esp-idf-4.4.2.exe">Mirror</a>
+                      - 1 GB</span>
+                </span>
+                <span class="release-notes"><a href="https://github.com/espressif/idf-installer/releases/tag/espressif-ide-2.6.0">Release Notes</a></span>
               </li>
 
               <li>


### PR DESCRIPTION
Prepare windows installer for espressif-ide v2.6.0 with esp-idf v4.4.2