### PR TITLE
export: add an alias for espsecure.py

### DIFF
--- a/src/Batch/idf_cmd_init.bat
+++ b/src/Batch/idf_cmd_init.bat
@@ -45,6 +45,7 @@ set PREFIX=%IDF_PYTHON% %IDF_PATH%
 DOSKEY idf.py=%PREFIX%\tools\idf.py $*
 DOSKEY esptool.py=%PREFIX%\components\esptool_py\esptool\esptool.py $*
 DOSKEY espefuse.py=%PREFIX%\components\esptool_py\esptool\espefuse.py $*
+DOSKEY espsecure.py=%PREFIX%\components\esptool_py\esptool\espsecure.py $*
 DOSKEY otatool.py=%PREFIX%\components\app_update\otatool.py $*
 DOSKEY parttool.py=%PREFIX%\components\partition_table\parttool.py $*
 

--- a/src/PowerShell/Initialize-Idf.ps1
+++ b/src/PowerShell/Initialize-Idf.ps1
@@ -48,6 +48,7 @@ if (-not $isEspIdfRoot) {
 function idf.py { &$PythonCommand "$IDF_PATH\tools\idf.py" $args }
 function esptool.py { &$PythonCommand "$IDF_PATH\components\esptool_py\esptool\esptool.py" $args }
 function espefuse.py { &$PythonCommand "$IDF_PATH\components\esptool_py\esptool\espefuse.py" $args }
+function espsecure.py { &$PythonCommand "$IDF_PATH\components\esptool_py\esptool\espsecure.py" $args }
 function otatool.py { &$PythonCommand "$IDF_PATH\components\app_update\otatool.py" $args }
 function parttool.py { &$PythonCommand "$IDF_PATH\components\partition_table\parttool.py" $args }
 


### PR DESCRIPTION
We already have aliases for esptool.py and espefuse.py, but were missing one for espsecure.py.

Same change will be applied in export.bat, export.ps1 in IDF.

Reported in https://esp32.com/viewtopic.php?t=30260.
