### PR TITLE
installer: fetch one tag after doing a shallow clone

### DIFF
--- a/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
@@ -111,6 +111,7 @@ CheckPermissionToFile=Prosím, ověřte oprávnění a restartujte instalaci.
 SwitchBranch=Přepnutí větve
 FinishingEspIdfInstallation=Dokončení instalace ESP-IDF
 CleaningUntrackedDirectories=Čistění složek, které nejsou verzovány
+FetchingTags=Fetching tags
 ExtractingEspIdf=Rozbalování ESP-IDF
 SettingUpReferenceRepository=Vytváření referenčního repositáře
 DownloadingEspIdf=Stahování ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
@@ -111,6 +111,7 @@ CheckPermissionToFile=Please check the file access and retry the installation.
 SwitchBranch=Switching branch
 FinishingEspIdfInstallation=Finishing ESP-IDF installation
 CleaningUntrackedDirectories=Cleaning untracked directories
+FetchingTags=Fetching tags
 ExtractingEspIdf=Extracting ESP-IDF
 SettingUpReferenceRepository=Setting up reference repository
 DownloadingEspIdf=Downloading ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
@@ -112,6 +112,7 @@ CheckPermissionToFile=Por favor revise el acceso al archivo y reintente la insta
 SwitchBranch=Cambiando de rama
 FinishingEspIdfInstallation=Finalizando la instalación ESP-IDF
 CleaningUntrackedDirectories=Limpiando directorios sin seguimiento.
+FetchingTags=Fetching tags
 ExtractingEspIdf=Extrayendo ESP-IDF
 SettingUpReferenceRepository=Configurando repositorio de referencia
 DownloadingEspIdf=Descargando ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
@@ -112,6 +112,7 @@ CheckPermissionToFile=Por favor verifique a permissão de acesso do arquivo e te
 SwitchBranch=Alterando o branch
 FinishingEspIdfInstallation=Finalizando a instalação do ESP-IDF
 CleaningUntrackedDirectories=Limpando os diretórios não rastreados
+FetchingTags=Fetching tags
 ExtractingEspIdf=Extraindo o ESP-IDF
 SettingUpReferenceRepository=Configurando a referência do repositório
 DownloadingEspIdf=Baixando o ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
@@ -112,6 +112,7 @@ CheckPermissionToFile=Por favor verifique a permissão de acesso do ficheiro e t
 SwitchBranch=Alterando o branch
 FinishingEspIdfInstallation=A finalizar a instalação do ESP-IDF
 CleaningUntrackedDirectories=A limpar os diretórios não rastreados
+FetchingTags=Fetching tags
 ExtractingEspIdf=A extrair o ESP-IDF
 SettingUpReferenceRepository=A configurar a referência do repositório
 DownloadingEspIdf=Descarregando o ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
@@ -111,6 +111,7 @@ CheckPermissionToFile=Prosím, overte oprávnenia a reštartujte inštaláciu.
 SwitchBranch=Prepnutie vetvy
 FinishingEspIdfInstallation=Dokončenie inštalácie ESP-IDF
 CleaningUntrackedDirectories=Čistenie zložiek, ktoré nie sú verzované
+FetchingTags=Fetching tags
 ExtractingEspIdf=Rozbaľovanie ESP-IDF
 SettingUpReferenceRepository=Vytváranie referenčného repozitára
 DownloadingEspIdf=Preberanie ESP-IDF

--- a/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
@@ -111,6 +111,7 @@ CheckPermissionToFile=请检查文件权限并重试安装。
 SwitchBranch=切换分支
 FinishingEspIdfInstallation=完成 ESP-IDF 安装
 CleaningUntrackedDirectories=清理未跟踪的目录
+FetchingTags=Fetching tags
 ExtractingEspIdf=提取 ESP-IDF
 SettingUpReferenceRepository=设置参考仓库
 DownloadingEspIdf=下载 ESP-IDF


### PR DESCRIPTION
When the installer downloads a release branch, creation of local IDF repository is done in two stages:

1. Download the zip file of one of the releases on the same branch, extract it in a temporary directory.
2. Perform git clone, using the extracted directory as reference.

In the 2nd step, we may perform "shallow" clone if such option is chosen by the user. Shallow repository doesn't contain any tags, so "git describe" will later not work correctly in the repository. In particular, IDF build system will not determine the version correctly, which can be seen in the output of the 2nd stage bootloader.

This is a partial fix to the problem. In order to make "git describe" work, we fetch one of the tags from the same release branch.

Note that this fix still doesn't solve the issue in two cases:
- If no release tag exists for this branch. For example, release/v5.1 has been already created and added to idf_versions.txt, but no tagged release is available yet.
- When cloning the master branch.

Possible fix for https://github.com/espressif/esp-idf/issues/10342.

## TODOs
- [ ] Verify this fix locally
- [ ] Update the translations for the new message