### PR TITLE
Generate installers for Espressif-IDE v2.9.1 with ESP-IDF 5.0.1

### DIFF
--- a/.github/workflows/build-espressif-ide-installer.yml
+++ b/.github/workflows/build-espressif-ide-installer.yml
@@ -11,11 +11,15 @@ on:
         description: 'ESP-IDF version'
         required: true
         default: '5.0.1'
+      python_version:
+        description: 'ESP-IDF version'
+        required: true
+        default: '3.11'
 
 jobs:
   build-espressif-ide-installer:
     name: Build Installer
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -26,10 +30,10 @@ jobs:
       - name: Install Inno Setup
         shell: pwsh
         run: choco install innosetup
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '${{ github.event.inputs.python_version }}'
       - name: Install Inno Setup Download plugin
         shell: pwsh
         run: Invoke-WebRequest -Uri https://github.com/espressif/inno-download-plugin/releases/download/v1.5.1/idpsetup-1.5.1.exe -OutFile idpsetup.exe; .\idpsetup.exe /SILENT; Sleep 5
@@ -39,7 +43,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
         shell: pwsh
         working-directory: "P:"
-        run: .\Build-Installer.ps1 -InstallerType espressif-ide -OfflineBranch "v${{ github.event.inputs.esp_idf_version }}" -EspressifIdeVersion "${{ github.event.inputs.espressif_ide_version }}"
+        run: .\Build-Installer.ps1 -InstallerType espressif-ide -OfflineBranch "v${{ github.event.inputs.esp_idf_version }}" -EspressifIdeVersion "${{ github.event.inputs.espressif_ide_version }}" -Python "python"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/build-espressif-ide-installer.yml
+++ b/.github/workflows/build-espressif-ide-installer.yml
@@ -6,7 +6,7 @@ on:
       espressif_ide_version:
         description: 'Espressif IDE version'
         required: true
-        default: '2.9.0'
+        default: '2.9.1'
       esp_idf_version:
         description: 'ESP-IDF version'
         required: true

--- a/.github/workflows/build-espressif-ide-installer.yml
+++ b/.github/workflows/build-espressif-ide-installer.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Map local long path to new drive
         id: map_path
         shell: pwsh

--- a/.github/workflows/build-offline-installer.yml
+++ b/.github/workflows/build-offline-installer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/build-online-installer-dispatch.yml
+++ b/.github/workflows/build-online-installer-dispatch.yml
@@ -53,7 +53,7 @@ jobs:
           ASSET_NAME: 'idf-installer-windows.exe'
           ASSET_CONTENT_TYPE: 'application/octet-stream'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: setup node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build-online-installer.yml
+++ b/.github/workflows/build-online-installer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/test-offline-installer-dispatch.yml
+++ b/.github/workflows/test-offline-installer-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Installer
         run: |
           $ProgressPreference = 'SilentlyContinue'

--- a/.github/workflows/test-online-installer-dispatch.yml
+++ b/.github/workflows/test-online-installer-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Installer
         run:  Invoke-WebRequest ${{ github.event.inputs.installer_url }} -OutFile installer.exe
         shell: pwsh

--- a/.github/workflows/test-online-installer-scheduled.yml
+++ b/.github/workflows/test-online-installer-scheduled.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Installer
         run:  Invoke-WebRequest https://github.com/espressif/idf-installer/releases/download/online-2.14/esp-idf-tools-setup-online-2.14.exe -OutFile installer.exe
         shell: pwsh

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.4.1
         with:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note: Online Installer is recommended way of the installation.
 
 | Version | Content | Size |
 | ------- | ------- | ---- |
+| Espressif-IDE v2.9.1 and ESP-IDF 5.0.1 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.9.1-esp-idf-5.0.1/espressif-ide-setup-2.9.1-with-esp-idf-5.0.1.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.9.1-with-esp-idf-5.0.1.exe) | Espressif-IDE 2.9.1 + JDK 17 + ESP-IDF v5.0.1 | 1 GB |
 | Espressif-IDE v2.9.0 and ESP-IDF 5.0.1 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.9.0-esp-idf-5.0.1/espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe) | Espressif-IDE 2.9.0 + JDK 17 + ESP-IDF v5.0.1 | 1 GB |
 | Espressif-IDE v2.8.1 and ESP-IDF 5.0 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.8.1-esp-idf-5.0/espressif-ide-setup-2.8.1-with-esp-idf-5.0.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.8.1-with-esp-idf-5.0.exe) | Espressif-IDE + JDK + ESP-IDF v5.0 | 1 GB |
 | Espressif-IDE v2.8.1 and ESP-IDF 4.4.4 [download](https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.8.1-esp-idf-4.4.4/espressif-ide-setup-2.8.1-with-esp-idf-4.4.4.exe)/[mirror](https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.8.1-with-esp-idf-4.4.4.exe) | Espressif-IDE + JDK + ESP-IDF v5.0 | 1 GB |

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -43,7 +43,7 @@
 #define GitInstallerDownloadURL "https://dl.espressif.com/dl/idf-git/" + GitInstallerName
 
 #ifndef ESPRESSIFIDEVERSION
-  #define ESPRESSIFIDEVERSION "2.9.0"
+  #define ESPRESSIFIDEVERSION "2.9.1"
 #endif
 
 #define ECLIPSE_INSTALLER "Espressif-IDE-" + ESPRESSIFIDEVERSION + "-win32.win32.x86_64.zip"

--- a/src/Resources/download/index.html
+++ b/src/Resources/download/index.html
@@ -155,10 +155,10 @@
                 </form>
             </div>
             <div class="download-button">
-                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.9.0-with-esp-idf-5.0.1.exe">
+                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.9.1-with-esp-idf-5.0.1.exe">
                     <button class="button-espressif-ide">
                         <i class="fa fa-download" aria-hidden="true"></i>
-                        <div>Espressif-IDE 2.9.0 with ESP-IDF v5.0.1</div>
+                        <div>Espressif-IDE 2.9.1 with ESP-IDF v5.0.1</div>
                         <div>Windows 10, 11</div>
                         <div>Size: 1 GB</div>
                     </button>
@@ -291,6 +291,18 @@
                       - 4 MB</span>
                 </span>
                 <span class="release-notes"><a href="https://github.com/espressif/idf-installer/releases/tag/online-2.20">Release Notes</a></span>
+              </li>
+
+              <!-- Release Espressif IDE 2.9.1 with ESP-IDF 5.0.1 -->
+              <li>
+                <span class="release-number">Espressif-IDE 2.9.1 with ESP-IDF v5.0.1</span>
+                <span class="release-date">2023-04-10</span>
+                <span class="release-download">
+                    <span><a href="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-2.9.1-with-esp-idf-5.0.1.exe">Download</a> /
+                        <a href="https://github.com/espressif/idf-installer/releases/download/espressif-ide-2.9.1-esp-idf-5.0.1/espressif-ide-setup-2.9.1-with-esp-idf-5.0.1.exe">Mirror</a>
+                        - 1 GB</span>
+                </span>
+                <span class="release-notes"><a href="https://github.com/espressif/idf-installer/releases/tag/espressif-ide-2.9.1-esp-idf-5.0.1">Release Notes</a></span>
               </li>
 
               <!-- Release Espressif IDE 2.9.0 with ESP-IDF 5.0.1 -->


### PR DESCRIPTION
Generate installers for[ Espressif-IDE v2.9.1](https://github.com/espressif/idf-eclipse-plugin/releases/tag/v2.9.1) with ESP-IDF 5.0.1