### PR TITLE
IEP-1054: Offline installer missing quotes

### DIFF
--- a/src/InnoSetup/Configuration.iss
+++ b/src/InnoSetup/Configuration.iss
@@ -312,7 +312,7 @@ begin
   Content := Content + '    "' + IdfId + '": {' + #13#10;
   Content := Content + '      "version": "' + IdfVersion + '",' + #13#10;
   Content := Content + '      "path": "' + IdfPathWithForwardSlashes + '",' + #13#10;
-  Content := Content + '      "python": "' + GetPathWithForwardSlashes(GetPythonVirtualEnvExecutable()) + #13#10;
+  Content := Content + '      "python": "' + GetPathWithForwardSlashes(GetPythonVirtualEnvExecutable()) + '"' + #13#10;
   Content := Content + '    }' + #13#10;
   Content := Content + '  }' + #13#10;
   Content := Content + '}' + #13#10;


### PR DESCRIPTION
IDF installer is building the esp_idf.json file with missing double quotes