### PR TITLE
Feat/version of idf source specification

### DIFF
--- a/.github/workflows/bundle-git.yml
+++ b/.github/workflows/bundle-git.yml
@@ -1,0 +1,55 @@
+name: bundle-git
+
+on:
+  workflow_dispatch:
+    inputs:
+      Git_version:
+        description: >
+          Git version to be bundled
+        type: string
+        required: true
+        default: '2.43.0'
+
+jobs:
+  build-distro:
+    name: Bundle Git for Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Bundle script
+        run: .\Bundle-Git.ps1 -GitVersion ${{ inputs.Git_version }}
+        shell: pwsh
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.Git_version }}
+          release_name: Release Git ${{ inputs.Git_version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./idf-git-${{ inputs.Git_version}}-win64.zip
+          asset_name: idf-git-${{ inputs.Git_version }}-win64.zip
+          asset_content_type: application/zip
+
+      - name: Upload Release Asset To dl.espressif.com
+        id: upload-release-asset-espressif
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        shell: pwsh
+        run: aws s3 cp --acl=public-read --no-progress ./idf-git-${{ inputs.Git_version }}-win64.zip s3://${{ secrets.DL_BUCKET }}/dl/idf-git/idf-git-${{ inputs.Git_version }}-win64.zip

--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -11,7 +11,7 @@ param (
     [String]
     $IdfPythonShortVersion = '3.11',
     [String]
-    $GitVersion = '2.39.2',
+    $GitVersion = '2.43.0',
     [String]
     [ValidateSet('online', 'offline', 'espressif-ide')]
     $InstallerType = 'online',

--- a/Bundle-Git.ps1
+++ b/Bundle-Git.ps1
@@ -1,0 +1,40 @@
+param (
+    [string]$GitVersion="2.43.0"
+)
+
+$GitDirectory = "idf-git-${GitVersion}-win64"
+
+
+# Download Git
+Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v${GitVersion}.windows.1/PortableGit-${GitVersion}-64-bit.7z.exe" -OutFile git.7z.exe
+
+# Test and download/run 7z
+$7z = 'C:/Program Files/7-Zip/7z.exe'
+"Test if directory [$7z] exists"
+if (Test-Path -Path $7z) {
+    "Path exists!"
+    7z x git.7z.exe
+    Rename-Item -Path "git" -NewName ${GitDirectory}
+} else {
+    "Path doesn't exist."
+    # Install 7zip PS module
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls13
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+    Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
+    Install-Module -Name 7Zip4PowerShell -Force
+
+    # Extract 7zip file
+    Expand-7Zip -ArchiveFileName "git.7z.exe" -TargetPath ${GitDirectory}
+}
+
+Start-Process "${GitDirectory}\post-install.bat" -ArgumentList "/s" -Wait
+
+# Clean directory
+Remove-Item "git.7z.exe"
+Remove-Item "${GitDirectory}\dev" -Recurse
+Remove-Item "${GitDirectory}\tmp"
+Remove-Item "${GitDirectory}\README.portable"
+
+# Create final zip - GitHub performs compression of artifacts automatically
+Compress-Archive -Path "${GitDirectory}\*" -DestinationPath "${GitDirectory}.zip"
+Remove-Item "${GitDirectory}" -Recurse -Force

--- a/README.md
+++ b/README.md
@@ -441,3 +441,14 @@ cp file.ini file.isl
 ```
 
 - add BOM header using Save function in Visual Studio Code
+
+## Bundle Git
+
+Repackage of Git for Windows. Git for Windows is provided in ```.7z.exe``` format, the workflow with script repackages it to ```.zip``` format and uploads it to Espressif's download server where it is used by IDF-installer.
+
+### How to use bundle Git
+
+* Check the version of Git on the website https://git-scm.com/download/win
+* Use the version as input into the manual workflow run
+* Run the workflow ```.github/workflow/bundle-git.yaml`
+* On success the Git version will be on Espressif's download server

--- a/src/InnoSetup/Pages/IdfDownloadPage.iss
+++ b/src/InnoSetup/Pages/IdfDownloadPage.iss
@@ -38,9 +38,9 @@ begin
   else if WildCardMatch(Version, 'v*-rc*') then
     Result := 'pre-release version'
   else if WildCardMatch(Version, 'v*') then
-    Result := 'release version'
+    Result := 'release version - .zip archive download'
   else if WildCardMatch(Version, 'release/v*') then
-    Result := 'release branch'
+    Result := 'release branch - git clone'
   else if WildCardMatch(Version, 'master') then
     Result := 'development branch'
   else


### PR DESCRIPTION
- Updated installer Git version
- Added installation sources for user chosen installation options
- Added git bundle workflow - bundles Git for Windows to `.zip` archive and uploads it to Espressif's download server

It is related to issue: https://github.com/espressif/esp-idf/issues/12821