### PR TITLE
feature: Changed all installer git versions

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -37,7 +37,7 @@
 ;#define PythonInstallerDownloadURL "https://github.com/espressif/idf-python/releases/download/v" + PYTHONVERSION + "/idf-python-" + PYTHONVERSION + "-embed-win64.zip"
 
 #ifndef GITVERSION
-  #define GITVERSION "2.39.2"
+  #define GITVERSION "2.43.0"
 #endif
 #define GitInstallerName "idf-git-" + GITVERSION + "-win64.zip"
 #define GitInstallerDownloadURL "https://dl.espressif.com/dl/idf-git/" + GitInstallerName

--- a/src/InnoSetup/Summary.iss
+++ b/src/InnoSetup/Summary.iss
@@ -19,7 +19,7 @@ begin
 
   if (UseEmbeddedGit) then begin
     { app is know only in this section, it's not possible to set it in Page }
-    GitPath := ExpandConstant('{app}\tools\idf-git\2.39.2\cmd\');
+    GitPath := ExpandConstant('{app}\tools\idf-git\2.43.0\cmd\');
     GitExecutablePath := GitPath + 'git.exe';
 
     Result := Result + CustomMessage('UsingEmbeddedGit') + ' ' + GitVersion + ':' + NewLine


### PR DESCRIPTION
- Changed all occurrences of git version in installer
- New full Git for Windows version from https://git-scm.com/download is used
- The automatic workflow can be used in future to download and upload Git for Windows on Espressif's download server (`bundle-git.yml`) and also create an release

- Action for acquiring minigit `update-idf-git` can be suspended because it is basically duplicate of `bundle-git.yml` but with minigit version