### PR TITLE
fix: Changed parameter -O to -OutFile for Invoke-WebRequest function

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -60,7 +60,7 @@ function DownloadIdfVersions() {
         return
     }
     "Downloading idf_versions.txt..."
-    Invoke-WebRequest -O $Versions https://dl.espressif.com/dl/esp-idf/idf_versions.txt
+    Invoke-WebRequest -OutFile $Versions https://dl.espressif.com/dl/esp-idf/idf_versions.txt
 }
 
 # Get short version of Constraint file.
@@ -76,7 +76,7 @@ function PrepareConstraints {
     $ConstraintFile = GetConstraintFile
     $ConstraintUrl = "https://dl.espressif.com/dl/esp-idf/$ConstraintFile"
     "Downloading $ConstraintUrl"
-    Invoke-WebRequest -O "build\$InstallerType\${ConstraintFile}" $ConstraintUrl
+    Invoke-WebRequest -OutFile "build\$InstallerType\${ConstraintFile}" $ConstraintUrl
 }
 
 function PrepareIdfPackage {
@@ -108,7 +108,7 @@ function PrepareIdfPackage {
     "Checking existence of dist: $FullDistZipPath"
     if (-Not(Test-Path -Path $FullDistZipPath -PathType Leaf)) {
         "Downloading from $DownloadUrl to $FullDistZipPath"
-        Invoke-WebRequest -O $FullDistZipPath $DownloadUrl
+        Invoke-WebRequest -OutFile $FullDistZipPath $DownloadUrl
     }
 
     if ("" -ne $StripDirectory) {
@@ -139,7 +139,7 @@ function PrepareIdfFile {
     }
 
     "Downloading: $DownloadUrl"
-    Invoke-WebRequest -O $FullFilePath $DownloadUrl
+    Invoke-WebRequest -OutFile $FullFilePath $DownloadUrl
 }
 
 function PrepareIdfCmdlinerunner {


### PR DESCRIPTION
IDF Installer is not possible to build because of 

> ambiguous parameter name 'O' 

in the `Invoke-WebRequest` function. [Here is the failed build](https://github.com/espressif/idf-installer/actions/runs/8061393369/job/22019073286) which should be fixed by this change. The build has successfully passed locally.