### PR TITLE
fix: Update online installers with Espressif-IDE v2.12.1

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -43,7 +43,7 @@
 #define GitInstallerDownloadURL "https://dl.espressif.com/dl/idf-git/" + GitInstallerName
 
 #ifndef ESPRESSIFIDEVERSION
-  #define ESPRESSIFIDEVERSION "2.9.1"
+  #define ESPRESSIFIDEVERSION "2.12.1"
 #endif
 
 #define ECLIPSE_INSTALLER "Espressif-IDE-" + ESPRESSIFIDEVERSION + "-win32.win32.x86_64.zip"


### PR DESCRIPTION
Update online installers with Espressif-IDE v2.12.1 which is the recent version of the IDE.