### PR TITLE
fix: Fixed running called worflow only for chosen installer type

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -35,7 +35,7 @@ env:
 jobs:
     build-installer-online:
         name: Build Online Installer
-        if: ${{ github.env.INSTALLER_TYPE }} == 'online'
+        if: inputs.installer_type == 'online'
         uses: espressif/idf-installer/.github/workflows/build-online-installer.yml@main
         with:
             online_installer_version: ${{ inputs.online_installer_version }}
@@ -43,7 +43,7 @@ jobs:
 
     build-installer-offline:
         name: Build Offline Installer
-        if: ${{ github.env.INSTALLER_TYPE }} == 'offline'
+        if: inputs.installer_type == 'offline'
         uses: espressif/idf-installer/.github/workflows/build-offline-installer.yml@main
         with:
             esp_idf_version: ${{ inputs.esp_idf_version}}
@@ -51,7 +51,7 @@ jobs:
 
     build-installer-ide:
         name: Build IDE Installer
-        if: ${{ github.env.INSTALLER_TYPE }} == 'espressif-ide'
+        if: inputs.installer_type == 'espressif-ide'
         uses: espressif/idf-installer/.github/workflows/build-espressif-ide-installer.yml@main
         with:
             esp_idf_version: ${{ inputs.esp_idf_version }}

--- a/scripts/docs_update_release.py
+++ b/scripts/docs_update_release.py
@@ -160,7 +160,7 @@ def main():
     supported_idf_versions = eval(environ.get('SUPPORTED_IDF_VERSIONS', "('5.2', '4.4', '5.1', '5.0')"))    # e.g. ('5.2', '4.4', '5.1', '5.0')
     supported_idf_versions = list(supported_idf_versions)
 
-    if not idf_version:
+    if not idf_version and installer_type != 'online':
         raise SystemExit("ERROR: IDF version is not provided")
     
     # cast IDF version to list


### PR DESCRIPTION
- Installer choice input fix
- IDF version doesn't need to be specified for online installer type