### PR TITLE
Fix: IDF tools PATH was updated to be not allowed to pass with spaces

### DIFF
--- a/src/InnoSetup/Pages/IdfPage.iss
+++ b/src/InnoSetup/Pages/IdfPage.iss
@@ -177,6 +177,7 @@ begin
     begin
       MessageBox(CustomMessage('SpacesInPathNotSupported') + #13#10 +
              CustomMessage('ChooseDifferentDirectory'), mbError, MB_OK);
+      Result := False;
       exit;
     end;
 


### PR DESCRIPTION
- When user presents IDF Tools PATH with spaces the error message is shown but the installation process proceeds to the next page with the PATH with spaces
- This fix won't allow the installation process to continue if the PATH of IDF tools contains spaces

Internal tracker: IDF-9702