### PR TITLE
fix: Uninstallation of whole ESP-IDF

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -335,6 +335,8 @@ Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\releases"
 Type: filesandordirs; Name: "{app}\tools"
 Type: filesandordirs; Name: "{app}\python_env"
+Type: filesandordirs; Name: "{app}"
+Type: filesandordirs; Name: "{autostartmenu}\Programs\ESP-IDF"
 ;Type: files; Name: "{group}\{#IDFCmdExeShortcutFile}"
 ;Type: files; Name: "{group}\{#IDFPsShortcutFile}"
 ;Type: files; Name: "{autodesktop}\{#IDFCmdExeShortcutFile}"
@@ -366,6 +368,7 @@ Filename: "{app}\idf-env.exe"; Parameters: "antivirus exclusion add --all"; Flag
 
 
 [UninstallRun]
+Filename: "{cmd}"; Parameters: "/C del /q ""{autodesktop}\ESP-IDF*PowerShell*"" ""{autodesktop}\ESP-IDF*CMD*"""
 Filename: "{app}\idf-env.exe"; \
   Parameters: "antivirus exclusion remove --all"; \
   WorkingDir: {app}; Flags: runhidden


### PR DESCRIPTION
Added to uninstallation of ESP-IDF:

- Whole IDF directory (including frameworks directory, constraints files, ...)
- Start menu icons
- Desktop shortcuts

----------
### Related
- GH issue: https://github.com/espressif/esp-idf/issues/13657