### PR TITLE
fix(performcmdinstall): Exit blocking wait loop after some time to no…

### DIFF
--- a/src/InnoSetup/Pages/CmdlinePage.iss
+++ b/src/InnoSetup/Pages/CmdlinePage.iss
@@ -115,6 +115,7 @@ var
   LogText, LeftOver: String;
   Memo: TNewMemo;
   PrevCancelButtonOnClick: TNotifyEvent;
+  MaxIterations: Integer;
 begin
   CmdlineInstallPage := CreateOutputProgressPage('', '')
   CmdlineInstallPage.Caption := caption;
@@ -147,7 +148,13 @@ begin
       Log('ProcStart failed');
       ExitCode := -2;
     end;
-    while (ExitCode = -1) and not CmdlineInstallCancel do
+    
+    { Following number MaxIterations is not hard defined }
+    { it only has to be based on execution times of the instructions inside the loop and CPU ticks }
+    { to fulfill this need heuristic technique was applied to define this number }
+    { also, it has been taken into mind the loop has to exit within 5 minutes which is probably the maximal time user would wait }
+    MaxIterations := 40000;
+    while (ExitCode = -1) and not CmdlineInstallCancel and not (MaxIterations = 0) do
     begin
       ExitCode := ProcGetExitCode(Handle);
       SetLength(LogTextAnsi, 4096);
@@ -160,6 +167,7 @@ begin
       end;
       CmdlineInstallPage.SetProgress(0, 100);
       Sleep(10);
+      MaxIterations := MaxIterations - 1;
     end;
     ProcEnd(Handle);
   finally


### PR DESCRIPTION
When there is no successful `exit-code` from the function that is the Installer waiting for, there is no mechanism to exit from this loop which causes the installation process to hang in this state indefinitely.
Since the issue mentioned by the user can not be reproduced, I have tested this  with the new build of online installer and everything seems to work.

This PR is a proposal to fix this.

- Closes https://github.com/espressif/esp-idf/issues/13967