### PR TITLE
fix: Fixed links for older releases of Installer

### DIFF
--- a/.github/workflows/build-espressif-ide-installer.yml
+++ b/.github/workflows/build-espressif-ide-installer.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: espressif-ide-${{ inputs.espressif_ide_version }}-esp-idf-${{ inputs.esp_idf_version }}
+          tag_name: espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}
           release_name: Release of Espressif IDE ${{ inputs.espressif_ide_version }} with ESP-IDF ${{ inputs.esp_idf_version }}
           draft: true
           prerelease: true
@@ -79,7 +79,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/espressif-ide-setup-espressif-ide-with-esp-idf-${{ inputs.esp_idf_version }}-signed.exe
-          asset_name: espressif-ide-setup-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}.exe
+          asset_name: esp-idf-tools-setup-espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}.exe
           asset_content_type: application/octet-stream
 
       - name: Upload Release Asset To dl.espressif.com

--- a/.github/workflows/build-offline-installer.yml
+++ b/.github/workflows/build-offline-installer.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.VERSION }}-esp-idf-v${{ env.IDF_BRANCH }}
+          tag_name: ${{ env.VERSION }}
           release_name: Release ${{ env.VERSION }}
           draft: false
           prerelease: false

--- a/src/Resources/templates/template_index.html
+++ b/src/Resources/templates/template_index.html
@@ -154,7 +154,7 @@ window.onload = () => {
 
             let description = installerTitle[release.type] + ' v' + release.version;
             let downloadLink = 'https://github.com/espressif/idf-installer/releases/download/' + release.type + '-' + release.version + '/esp-idf-tools-setup-' + release.type + '-' + release.version + '.exe';
-            let mirrorLink = 'https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-' + release.type + '-' + release.version;
+            let mirrorLink = 'https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-' + release.type + '-' + release.version + '.exe';
             let releaseNotesLink = 'https://github.com/espressif/idf-installer/releases/tag/' + release.type + '-' + release.version;
 
             const listItem = document.createElement('li');
@@ -205,7 +205,7 @@ window.onload = () => {
             </div>
 
             <div class="download-button">
-                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-{{ espressif_ide.version }}-with-esp-idf-{{ espressif_ide.idf_version }}.exe">
+                <form method="get" action="https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-espressif-ide-{{ espressif_ide.version }}-with-esp-idf-{{ espressif_ide.idf_version }}.exe">
                     <button class="button-espressif-ide">
                         <i class="fa fa-download" aria-hidden="true"></i>
                         <div>Espressif-IDE {{ espressif_ide.version }} with ESP-IDF v{{ espressif_ide.idf_version }} - Offline Installer</div>


### PR DESCRIPTION
Based on the reported issue, the fix for the older IDF Installer releases in [Espressif's download server](https://dl.espressif.com/dl/esp-idf/) is provided.

* Fixed automatic tag and asset name generation to correspond with the links
* Changed the tag and asset names already released to make the links work

## Related
* Closes https://github.com/espressif/idf-installer/issues/254