### PR TITLE
feat(build): Added check for PrepareIdfDriver function

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -244,6 +244,9 @@ function PrepareIdfEclipse {
 
 function PrepareIdfDriver {
     &".\build\$InstallerType\lib\idf-env.exe" driver download --espressif --ftdi --silabs --wch
+    if ($LASTEXITCODE -ne 0) {
+        FailBuild -Message "Command failed with exit code: $LASTEXITCODE. Aborting."
+    }
 }
 
 function PrepareOfflineBranches {


### PR DESCRIPTION
## Description
The `PrepareIdfDriver` function was not checked and the build could pass even with the driver download/extract failure - this leads to the failure of the installation process with this installer build.

## Related
* internal tracker - IDF-10959