### PR TITLE
Installer improvements

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -24,7 +24,7 @@ param (
     [String]
     $SetupCompiler = 'iscc',
     [String]
-    $IdfEnvVersion = '1.2.31',
+    $IdfEnvVersion = '1.2.32',
     [String]
     $EspressifIdeVersion = '2.9.0',
     [String]

--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -176,6 +176,30 @@ function PrepareIdfPython {
         -DownloadUrl https://dl.espressif.com/dl/idf-python/idf-python-${IdfPythonVersion}-embed-win64.zip
 }
 
+function PrepareIdfDocumentation {
+    $FullFilePath = ".\build\$InstallerType\IDFdocumentation.pdf"
+    $DownloadUrl = "https://docs.espressif.com/projects/esp-idf/en/stable/esp32/esp-idf-en-$OfflineBranch-esp32.pdf"
+
+    if (Test-Path -Path $FullFilePath -PathType Leaf) {
+        "$FullFilePath found."
+        return
+    }
+
+    "Downloading: $DownloadUrl"
+    try {
+	    $Request = Invoke-WebRequest $DownloadUrl -OutFile $FullFilePath -MaximumRedirection 0
+        [int]$StatusCode = $Request.StatusCode
+    }
+    catch {
+        [int]$StatusCode = $_.Exception.Response.StatusCode
+    }
+
+
+    if ($StatusCode -eq 302) {
+        FailBuild -Message "Failed to download documentation from $DownloadUrl. Status code: $StatusCode"
+    }
+}
+
 function FailBuild {
     param (
         [Parameter()]
@@ -458,6 +482,7 @@ if (('offline' -eq $InstallerType) -or ('espressif-ide' -eq $InstallerType)){
     PrepareIdfDriver
     PrepareIdfGit
     PrepareIdfPython
+    PrepareIdfDocumentation
     if ('espressif-ide' -eq $InstallerType) {
         $IsccParameters += '/DESPRESSIFIDE=yes'
         $IsccParameters += '/DAPPNAME=Espressif-IDE'

--- a/scripts/docs_update_release.py
+++ b/scripts/docs_update_release.py
@@ -95,7 +95,7 @@ def update_index(releases, supported_idf_versions):
 
 
 
-def update_releases_json(new_idf_version: str, installer_type: str, online_installer_version: str, installer_size: str):
+def update_releases_json(new_idf_version: str, installer_type: str, online_installer_version: str,  ide_version: str, installer_size: str):
     """Update the releases.json file with the new release of the installer"""
     try:
         with open(path.abspath(RELEASES_JSON_PATH), "r") as releases_file:
@@ -108,8 +108,15 @@ def update_releases_json(new_idf_version: str, installer_type: str, online_insta
     except json.JSONDecodeError as e:
         raise SystemExit(f"Error parsing json: {e}")
 
+    if installer_type == 'online':
+        version = str(online_installer_version)
+    elif installer_type == 'offline':
+        version = str(new_idf_version)
+    elif installer_type == 'espressif-ide':
+        version = f'{ide_version}-with-esp-idf-{str(new_idf_version)}'
+    
     releases_json.insert(0, {
-            "version": str(new_idf_version) if installer_type != 'online' else str(online_installer_version),
+            "version": version,
             "type": str(installer_type),
             "date": str(date.today()),
             "size": str(installer_size)
@@ -190,7 +197,7 @@ def main():
     if installer_type == 'espressif-ide' and ide_version == '':
         raise SystemExit(f"ERROR: esp_ide_version or espressif_ide_version is not provided")
 
-    releases_json = update_releases_json(new_idf_version, installer_type, online_installer_version, installer_size)
+    releases_json = update_releases_json(new_idf_version, installer_type, online_installer_version, ide_version, installer_size)
 
     # Update App or IDE version if the installer type is not offline
     if installer_type != 'offline':

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -230,6 +230,10 @@ Source: "tools_fallback.json"; DestDir: "{app}"; DestName: "tools_fallback.json"
 Source: "..\Batch\idf_cmd_init.bat"; DestDir: "{app}";
 Source: "..\PowerShell\Initialize-Idf.ps1"; DestDir: "{app}";
 Source: "{#BUILD}\espidf.constraints.v*.txt"; DestDir: "{app}"; Flags: skipifsourcedoesntexist;
+; IDF Documentation
+#if OFFLINE == 'yes'
+Source: "{#BUILD}\IDFdocumentation.pdf"; DestDir: "{app}";
+#endif
 
 ; createallsubdirs is necessary for git repo. Otherwise empty directories disappears
 #ifdef FRAMEWORK_ESP_IDF
@@ -370,8 +374,16 @@ Filename: "{app}\dist\{#GitInstallerName}"; Parameters: "/silent /tasks="""" /no
 ;Filename: "{autodesktop}\{#IDFEclipseShortcutFile}"; Flags: runascurrentuser postinstall shellexec; Description: {cm:RunEclipse}; Components: "{#COMPONENT_ECLIPSE_DESKTOP}"
 ;#endif
 
-Filename: "{code:GetLauncherPathPowerShell}"; Flags: postinstall shellexec; Description: {cm:RunPowerShell}; Components: "{#COMPONENT_POWERSHELL_DESKTOP} {#COMPONENT_CMD_STARTMENU}"
-Filename: "{code:GetLauncherPathCMD}"; Flags: postinstall shellexec; Description: {cm:RunCmd}; Components: "{#COMPONENT_CMD_DESKTOP} {#COMPONENT_CMD_STARTMENU}";
+Filename: "{code:GetLauncherPathPowerShell}"; Flags: postinstall shellexec; Description: {cm:RunPowerShell}; Components: "{#COMPONENT_POWERSHELL_DESKTOP} {#COMPONENT_CMD_STARTMENU}"; Check: IsInstallSuccess;
+Filename: "{code:GetLauncherPathCMD}"; Flags: postinstall shellexec; Description: {cm:RunCmd}; Components: "{#COMPONENT_CMD_DESKTOP} {#COMPONENT_CMD_STARTMENU}"; Check: IsInstallSuccess;
+
+#if OFFLINE == 'no'
+Filename: "cmd"; Parameters: "/c start https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html"; Flags: nowait postinstall; Description: {cm:PointToDocumentation}; Check: IsInstallSuccess;
+#endif
+
+#if OFFLINE == 'yes'
+Filename: "cmd"; Parameters: "/c start """" ""{app}\IDFdocumentation.pdf"""; Flags: nowait postinstall; Description: {cm:PointToDocumentation}; Check: IsInstallSuccess;
+#endif
 
 ; WD registration checkbox is identified by 'Windows Defender' substring anywhere in its caption, not by the position index in WizardForm.TasksList.Items
 ; Please, keep this in mind when making changes to the item's description - WD checkbox is to be disabled on systems without the Windows Defender installed

--- a/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
@@ -88,6 +88,7 @@ InstallationMinimal=Minimální instalace
 InstallationCustom=Vlastní instalace
 RunInstallGit=Instalace Git
 RunEclipse=Spustit Espressif-IDE
+PointToDocumentation=Začněte s ESP-IDF - dokumentace
 RunPowerShell=Spustit ESP-IDF PowerShell Environment
 RunCmd=Spustit ESP-IDF Command Prompt Environment
 InstallationCancelled=Instalace byla zrušena.

--- a/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_cs-CZ.isl
@@ -35,6 +35,7 @@ SystemCheckApplyFixesConsent=Přejete si aplikovat opravy vašeho prostředí Wi
 SystemCheckFixesSuccessful=Opravy úspěšně aplikovány.
 SystemCheckFixesFailed=Aplikace oprav selhala. Bližší informace jsou dostupné pod tlačítkem Detail.
 SystemCheckNotCompleteConsent=Kontrola systému není hotová. Přejete si zastavit kontrolu a pokračovat bez ní?
+SystemCheckOldOS=Operační systém Windows již není podporován, mějte na vědomí, že instalační program nemusí fungovat správně.
 SystemCheckRootCertificates=Kontrola certifikátů
 SystemCheckRootCertificateWarning=Není možné načíst data ze serveru.
 SystemCheckForLongPathsEnabled=Kontrola podpory pro "Dlouhé cesty" ve Windows registrech

--- a/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
@@ -88,6 +88,7 @@ InstallationMinimal=Minimal installation
 InstallationCustom=Custom installation
 RunInstallGit=Installing Git
 RunEclipse=Run Espressif-IDE
+PointToDocumentation=Get started with the ESP-IDF - documentation
 RunPowerShell=Run ESP-IDF PowerShell Environment
 RunCmd=Run ESP-IDF Command Prompt Environment
 InstallationCancelled=Installation has been cancelled.

--- a/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_en-US.isl
@@ -35,6 +35,7 @@ SystemCheckApplyFixesConsent=Do you want to apply the commands with the suggeste
 SystemCheckFixesSuccessful=Successful application of Fixes.
 SystemCheckFixesFailed=Failed application of Fixes. Please refer to the Full log.
 SystemCheckNotCompleteConsent=System check is not complete. Do you want to proceed by skipping checks?
+SystemCheckOldOS=The OS is no longer supported. Please note that the installer may not work as expected.
 SystemCheckRootCertificates=Checking certificates
 SystemCheckRootCertificateWarning=Unable to load data from server.
 SystemCheckForLongPathsEnabled=Checking "Long Paths Enabled" in Windows registry

--- a/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
@@ -36,6 +36,7 @@ SystemCheckApplyFixesConsent=Quiere aplicar los comandos con los arreglos sugeri
 SystemCheckFixesSuccessful=Los arreglos se han aplicado con éxito.
 SystemCheckFixesFailed=Ha fallado la aplicación de arreglos. Consulte el log completo.
 SystemCheckNotCompleteConsent=Verificación del sistema no está completa. Quiere proceder saltando la verificación?
+SystemCheckOldOS=El sistema operativo ya no es compatible. Tenga en cuenta que es posible que el instalador no funcione como se espera.
 SystemCheckRootCertificates=Verificando certificados
 SystemCheckRootCertificateWarning=No es posible carga data del servidor
 SystemCheckForLongPathsEnabled=Verificando "Long Paths Enabled" en el registro de Windows

--- a/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_es-ES.isl
@@ -89,6 +89,7 @@ InstallationMinimal=Instalación mínima
 InstallationCustom=Instalación personalizada
 RunInstallGit=Instalando Git
 RunEclipse=Ejecutar ambiente Espressif-IDE
+PointToDocumentation=Comienza con de ESP-IDF - ​la documentación
 RunPowerShell=Ejecutar ambiente ESP-IDF PowerShell
 RunCmd=Ejecutar ambiente ESP-IDF Command Prompt
 InstallationCancelled=La instalación ha sido cancelada.

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
@@ -89,6 +89,7 @@ InstallationMinimal=Instalação mínima
 InstallationCustom=Instalação personalizada
 RunInstallGit=Instalando Git
 RunEclipse=Executar ambiente Espressif-IDE
+PointToDocumentation=Comece com o ESP-IDF - ​a documentação
 RunPowerShell=Executar o ambiente ESP-IDF PowerShell
 RunCmd=Executar ambiente ESP-IDF Prompt de Comando
 InstallationCancelled=A instalação foi cancelada.

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-BR.isl
@@ -36,6 +36,7 @@ SystemCheckApplyFixesConsent=Você quer aplicar os comandos com as correções s
 SystemCheckFixesSuccessful=Correções aplicadas com sucesso.
 SystemCheckFixesFailed=Aplicação das correções falhou. Por favor veja o log completo para maiores informações.
 SystemCheckNotCompleteConsent=Verificação do sistema não concluída. Deseja prosseguir sem a verificação do sistema?
+SystemCheckOldOS=O Sistema Operacional não é mais suportado. Observe que o instalador pode não funcionar como esperado.
 SystemCheckRootCertificates=Verificando certificados
 SystemCheckRootCertificateWarning=Não foi possível carregar dados do servidor.
 SystemCheckForLongPathsEnabled=Verificando registro "LongPathsEnabled" no sistema

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
@@ -89,6 +89,7 @@ InstallationMinimal=Instalação mínima
 InstallationCustom=Instalação personalizada
 RunInstallGit=A instalar Git
 RunEclipse=Executar ambiente Espressif-IDE
+PointToDocumentation=Comece com o ESP-IDF - documentação
 RunPowerShell=Executar o ambiente ESP-IDF PowerShell
 RunCmd=Executar ambiente ESP-IDF Prompt de Comando
 InstallationCancelled=A instalação foi cancelada.

--- a/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_pt-PT.isl
@@ -36,6 +36,7 @@ SystemCheckApplyFixesConsent=Você quer aplicar os comandos com as correções s
 SystemCheckFixesSuccessful=Correções aplicadas com sucesso.
 SystemCheckFixesFailed=Aplicação das correções falhou. Por favor veja o log completo para maiores informações.
 SystemCheckNotCompleteConsent=Verificação do sistema não concluída. Deseja prosseguir sem a verificação do sistema?
+SystemCheckOldOS=O sistema operativo já não é compatível. Note que o instalador pode não funcionar como esperado.
 SystemCheckRootCertificates=A verificar certificados
 SystemCheckRootCertificateWarning=Não foi possível carregar dados do servidor.
 SystemCheckForLongPathsEnabled=A verificar o registo "LongPathsEnabled" no sistema

--- a/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
@@ -35,6 +35,7 @@ SystemCheckApplyFixesConsent=Chcete spustiť aplikovanie opráv Vášho prostred
 SystemCheckFixesSuccessful=Aplikovanie opráv bolo úspešné.
 SystemCheckFixesFailed=Aplikovanie opráv sa nepodarilo. Detailné informácie sú dostupné pod tlačidlom Detaily.
 SystemCheckNotCompleteConsent=Kontrola systému ešte nie je hotová. Chcete kontrolu ukončiť a pokračovať bez kontroly?
+SystemCheckOldOS=Operačný systém už nie je podporovaný. Upozorňujeme, že inštalačný program nemusí fungovať podľa očakávania.
 SystemCheckRootCertificates=Kontrola certifikátov
 SystemCheckRootCertificateWarning=Nie je možné spojiť sa so serverom.
 SystemCheckForLongPathsEnabled=Kontrola podpory pre "Dlhé cesty" vo Windows registroch

--- a/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_sk-SK.isl
@@ -88,6 +88,7 @@ InstallationMinimal=Minimálna inštalácia
 InstallationCustom=Vlastná inštalácia
 RunInstallGit=Inštalácia Git-u
 RunEclipse=Spustiť Espressif-IDE
+PointToDocumentation=Začnite s ESP-IDF - dokumentácia
 RunPowerShell=Spustiť ESP-IDF PowerShell Environment
 RunCmd=Spustiť ESP-IDF Command Prompt Environment
 InstallationCancelled=Inštalácia bola zrušená.

--- a/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
@@ -88,6 +88,7 @@ InstallationMinimal=最小化安装
 InstallationCustom=自定义安装
 RunInstallGit=安装 Git
 RunEclipse=运行 Espressif-IDE 环境
+PointToDocumentation=開始使用 ESP-IDF - 文件
 RunPowerShell=运行 ESP-IDF PowerShell 环境
 RunCmd=运行 ESP-IDF 命令提示符环境
 InstallationCancelled=安装已取消。

--- a/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
+++ b/src/InnoSetup/Languages/IdfToolsSetup_zh-CN.isl
@@ -35,6 +35,7 @@ SystemCheckApplyFixesConsent=是否要应用经过建议修复的命令，以更
 SystemCheckFixesSuccessful=修复应用成功。
 SystemCheckFixesFailed=修复应用失败。请参阅完整日志。
 SystemCheckNotCompleteConsent=系统检查尚未完成。您想要跳过检查进行下一步吗？
+SystemCheckOldOS=不再支援該作業系統。請注意，安裝程式可能無法如預期般運作。
 SystemCheckRootCertificates=检查证书
 SystemCheckRootCertificateWarning=无法加载来自服务器 的数据。
 SystemCheckForLongPathsEnabled=检查 Windows 注册表中的“启用长路径”

--- a/src/InnoSetup/Pages/SystemCheckPage.iss
+++ b/src/InnoSetup/Pages/SystemCheckPage.iss
@@ -364,6 +364,8 @@ end;
 
 { Process user request to stop system checks. }
 function SystemCheckStopRequest():Boolean;
+var
+  Version: TWindowsVersion;
 begin
   { In case of stopped check by user, procees to next/previous step. }
   if (SystemCheckState = SYSTEM_CHECK_STATE_STOPPED) then begin
@@ -381,6 +383,10 @@ begin
 
   if (SystemCheckState = SYSTEM_CHECK_STATE_COMPLETE) then begin
     Result := True;
+    GetWindowsVersionEx(Version);
+    if (Version.Major < 10) then begin
+      MessageBox(CustomMessage('SystemCheckOldOS'), mbConfirmation, MB_OK)
+    end;
   end else begin
     Result := False;
   end;

--- a/src/InnoSetup/PostInstall.iss
+++ b/src/InnoSetup/PostInstall.iss
@@ -309,3 +309,29 @@ function IsCmdInstalled(): Boolean;
 begin
   Result := ((not SetupAborted) and (WizardIsTaskSelected('CreateLinkDeskCmd') or WizardIsTaskSelected('CreateLinkStartCmd')));
 end;
+
+// Installation completed check
+var
+  InstallSuccess: Boolean;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  // This event is called when the setup moves to a new step
+  if CurStep = ssPostInstall then
+  begin
+    // Set InstallSuccess to True after the installation has finished.
+    InstallSuccess := True;
+  end;
+end;
+
+function IsInstallSuccess: Boolean;
+begin
+  Result := InstallSuccess;
+end;
+
+<event('InitializeWizard')>
+procedure InitializeInstallSuccessVar;
+begin
+  // Initialize InstallSuccess to False
+  InstallSuccess := False;
+end;


### PR DESCRIPTION
- Fixed Action for installer build - the IDE installer type
- Added OS version check and note for the users
- Added option to open the documentation after completed installation
    - online installer opens the ESP-IDF website
    - offline installer has the ESP-IDF documentation bundled and opens the PDF
- Added successful installation check
    - Fixes unwanted opening of the `system` directory if the installation fails
- Updated IDF-ENV version because of the migration of the drivers to our server

<img width="449" alt="image" src="https://github.com/user-attachments/assets/eb5333b1-4ac8-4583-aeff-6d582558ed0d">

--- 
### Related
- Internal tracker  for the IDE installer fix: IDF-10094
- Installer improvements internal tracker: IDF-10040
