### PR TITLE
fix: Fixed offline documentation download URL

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -178,7 +178,7 @@ function PrepareIdfPython {
 
 function PrepareIdfDocumentation {
     $FullFilePath = ".\build\$InstallerType\IDFdocumentation.pdf"
-    $DownloadUrl = "https://docs.espressif.com/projects/esp-idf/en/stable/esp32/esp-idf-en-$OfflineBranch-esp32.pdf"
+    $DownloadUrl = "https://docs.espressif.com/projects/esp-idf/en/$OfflineBranch/esp32/esp-idf-en-$OfflineBranch-esp32.pdf"
 
     if (Test-Path -Path $FullFilePath -PathType Leaf) {
         "$FullFilePath found."


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

* The URL for the PDF download was fixed to be dynamically generated for the branches

## Related

Failing build: https://github.com/espressif/idf-installer/actions/runs/11214102858

## Testing

Fixed build: https://github.com/espressif/idf-installer/actions/runs/11214781512/job/31170576041

