### PR TITLE
fix: IDE Installer asset name uploaded on server

### DIFF
--- a/.github/workflows/build-espressif-ide-installer.yml
+++ b/.github/workflows/build-espressif-ide-installer.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           tag_name: espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}
           release_name: Release of Espressif IDE ${{ inputs.espressif_ide_version }} with ESP-IDF ${{ inputs.esp_idf_version }}
-          draft: true
-          prerelease: true
+          draft: false
+          prerelease: false
 
       - name: Get installer size and store it to file
         run: |
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/espressif-ide-setup-espressif-ide-with-esp-idf-${{ inputs.esp_idf_version }}-signed.exe
+          asset_path: ./build/esp-idf-tools-setup-espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}-signed.exe
           asset_name: esp-idf-tools-setup-espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}.exe
           asset_content_type: application/octet-stream
 
@@ -89,4 +89,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         shell: pwsh
-        run: aws s3 cp --acl=public-read --no-progress ./build/espressif-ide-setup-espressif-ide-with-esp-idf-${{ inputs.esp_idf_version }}-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/espressif-ide-setup-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}.exe
+        run: aws s3 cp --acl=public-read --no-progress ./build/esp-idf-tools-setup-espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}-signed.exe s3://${{ secrets.DL_BUCKET }}/dl/idf-installer/esp-idf-tools-setup-espressif-ide-${{ inputs.espressif_ide_version }}-with-esp-idf-${{ inputs.esp_idf_version }}.exe

--- a/src/Resources/download/index.html
+++ b/src/Resources/download/index.html
@@ -205,7 +205,7 @@ window.onload = () => {
             </div>
 
             <div class="download-button">
-                <form method="get" action="https://dl.espressif.com/dl/idf-installer/espressif-ide-setup-3.1.0-with-esp-idf-5.3.1.exe">
+                <form method="get" action="https://dl.espressif.com/dl/idf-installer/esp-idf-tools-setup-espressif-ide-3.1.0-with-esp-idf-5.3.1.exe">
                     <button class="button-espressif-ide">
                         <i class="fa fa-download" aria-hidden="true"></i>
                         <div>Espressif-IDE 3.1.0 with ESP-IDF v5.3.1 - Offline Installer</div>


### PR DESCRIPTION
## Description

* Updated IDE Installer URL for the Espressif server to correspond with the download page and the other installers
* Adjusted GH release creation to not be draft and pre-release

It would be better to manage the executable name generation in the scope of the calling workflow, but this would probably require passing artifacts. Since this installer is in the "feature freeze" state, this is the low-effort solution.

## Related

* Job with the bad URL: https://github.com/espressif/idf-installer/actions/runs/11214781512/job/31170576041
