### PR TITLE
fix(esp_clang): fixed the clang to be installed as part of offline installer

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -308,6 +308,7 @@ function PrepareOfflineBranches {
     }
 
     &$Python tools\idf_tools.py --tools-json tools/tools.json --non-interactive install
+    &$Python tools\idf_tools.py --tools-json tools/tools.json --non-interactive install esp-clang
     Pop-Location
 
     # Remove symlinks which are not supported on Windws, unfortunatelly -c core.symlinks=false does not work

--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -571,9 +571,14 @@ begin
   Log('Installing tools:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
   
-  CmdLine := IDFToolsPyCmd + ' install esp-clang';
+  CmdLine := IDFToolsPyCmd + ' --non-interactive install esp-clang';
   Log('Installing esp-clang:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspClangd'), '', CmdLine);
+  if (ResultCode = 1) then begin
+    Log("Clang installed");
+  end else begin
+    Log("Failed to install clang");
+  end;
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';

--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -570,10 +570,6 @@ begin
 
   Log('Installing tools:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
-  
-  CmdLine := IDFToolsPyCmd + ' --non-interactive install esp-clang';
-  Log('Installing esp-clang:' + CmdLine);
-  DoCmdlineInstall(CustomMessage('InstallingEspClangd'), '', CmdLine);
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';

--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -574,11 +574,6 @@ begin
   CmdLine := IDFToolsPyCmd + ' --non-interactive install esp-clang';
   Log('Installing esp-clang:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspClangd'), '', CmdLine);
-  if (ResultCode = 1) then begin
-    Log("Clang installed");
-  end else begin
-    Log("Failed to install clang");
-  end;
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';

--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -570,6 +570,10 @@ begin
 
   Log('Installing tools:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
+  
+  CmdLine := IDFToolsPyCmd + ' install esp-clang';
+  Log('Installing esp-clang:' + CmdLine);
+  DoCmdlineInstall(CustomMessage('InstallingEspClangd'), '', CmdLine);
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';


### PR DESCRIPTION
## Description

esp-clang made part of offline installer required for the Eclipse

## Related

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
