### PR TITLE
IDE Installer fix - idf_tools.py was not installing esp-clang

### DIFF
--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -570,6 +570,8 @@ begin
 
   Log('Installing tools:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
+  CmdLine := IDFToolsPyCmd + ' install esp-clang';
+  DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';


### PR DESCRIPTION
Resolving the issue reported on the ESP forum

## Description
There was a fix targeting IDE Installer but the online installer had this issue still preserved. This fix should cover all the cases.

* added installation of the esp-clang

## Related

* Internal tracker - IDF-11476
* IDE installer PR - https://github.com/espressif/idf-installer/pull/284
* issue on forum - https://esp32.com/viewtopic.php?f=40&t=42286

## Testing

* tested with the online installer and IDF v5.3.1