### PR TITLE
fix(jihulab): redirect the submodules' URL from github to jihulab

### DIFF
--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -340,6 +340,7 @@ var
   IDFTempPath: String;
   IDFPath: String;
   NeedToClone: Boolean;
+  ResultCode: Integer;
 begin
   IDFPath := IDFDownloadPath;
   { If there is a release archive to download, IDFZIPFileName and IDFZIPFileVersion will be set.
@@ -384,6 +385,10 @@ begin
         GitUseMirror := False;
         IsGitRecursive := True;
         GitRepository := 'https://jihulab.com/esp-mirror/espressif/esp-idf.git';
+        { Some submodules's submodule using absolute github url, redirect to jihulab }
+        if Exec(GitExecutablePath, + ' config --global url.https://jihulab.com/esp-mirror.insteadOf https://github.com', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+          Log('Git URLs redirect to jihulab.com succeeded');
+        end;
     end;
 
     CmdLine := GitExecutablePath + ' clone --progress -b ' + IDFDownloadVersion;
@@ -401,7 +406,25 @@ begin
 
     CmdLine := CmdLine + ' ' + GitRepository +' "' + IDFPath + '"';
     Log('Cloning IDF: ' + CmdLine);
-    DoCmdlineInstall(CustomMessage('DownloadingEspIdf'), CustomMessage('UsingGitToClone'), CmdLine);
+
+    if PerformCmdlineInstall(CustomMessage('DownloadingEspIdf'), CustomMessage('UsingGitToClone'), CmdLine) then begin
+      Log('Git clone completed');
+    end else begin
+      if (WizardIsComponentSelected('{#COMPONENT_OPTIMIZATION_GIT_MIRROR_JIHULAB}')) then begin
+        { Unset the redirect url before the exception return }
+        if Exec(GitExecutablePath, + ' config --global --unset url.https://jihulab.com/esp-mirror.insteadOf', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+          Log('Git URLs redirect to jihulab.com removed');
+        end;
+      end;
+      RaiseException(CustomMessage('InstallationFailedAtStep') + ' ' + CustomMessage('DownloadingEspIdf'));
+    end;
+
+    if (WizardIsComponentSelected('{#COMPONENT_OPTIMIZATION_GIT_MIRROR_JIHULAB}')) then begin
+      { Unset the redirect url after the clone }
+      if Exec(GitExecutablePath, + ' config --global --unset url.https://jihulab.com/esp-mirror.insteadOf', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+        Log('Git URLs redirect to jihulab.com removed');
+      end;
+    end;
 
     if IDFTempPath <> '' then
       GitRepoDissociate(IDFPath);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
Some submodules' submodules of ESP-IDF  use absolute paths from Github, which causes users to access Github at clone time even if they choose jihulab mirror. To allow users who do not have access to Github to complete the clone, this PR redirected these submodules to jihulab. the idea inspired by https://jihulab.com/esp-mirror/espressif/esp-jihu-tools @wujiangang


<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

* Test passed on Windows11
* The complete log can be found in [Setup Log 2024-06-26 #007.txt](https://github.com/user-attachments/files/17917174/Setup.Log.2024-06-26.007.txt)
* The git clone failed log [Setup Log 2024-11-26 #002.txt](https://github.com/user-attachments/files/17932252/Setup.Log.2024-11-26.002.txt)



![1732613041959_d](https://github.com/user-attachments/assets/e1e92c9d-8955-4405-b1d3-436ec253cdbe)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
