### PR TITLE
fix(CI): revert back change which references not existing branch name

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,7 +52,7 @@ jobs:
     build-installer-ide:
         name: Build IDE Installer
         if: inputs.installer_type == 'espressif-ide'
-        uses: espressif/idf-installer/.github/workflows/build-espressif-ide-installer.yml@fix/ide_installer_upload # TODO change !!!
+        uses: espressif/idf-installer/.github/workflows/build-espressif-ide-installer.yml@main
         with:
             esp_idf_version: ${{ inputs.esp_idf_version }}
             espressif_ide_version: ${{ inputs.espressif_ide_version }}


### PR DESCRIPTION
This reverts back the change did by https://github.com/espressif/idf-installer/pull/294. The referenced branch name doesn't exist anymore.

Because of this issue the release build action cannot be started.
