### PR TITLE
Disable Disc Spanning

### DIFF
--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -171,6 +171,7 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={sd}\Espressif
 UsePreviousAppDir=no
+DiskSpanning=no
 DirExistsWarning=no
 DefaultGroupName=ESP-IDF
 DisableProgramGroupPage=yes

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -171,7 +171,6 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={sd}\Espressif
 UsePreviousAppDir=no
-DiskSpanning=yes
 DirExistsWarning=no
 DefaultGroupName=ESP-IDF
 DisableProgramGroupPage=yes


### PR DESCRIPTION
The change that enabled disk spanning broke the automatic workflow for creating the installer. The newest release `[offline-5.4.1]` does not work.
The follow-up steps (signing and zipping) in the automatic workflow expect a single .exe file — not multiple files.

To restore the workflow, I reverted the change and explicitly disabled disk spanning.

@alirana01 Was there a specific reason for enabling it? If not, we’d appreciate keeping the current setup as-is, since the workflow depends on it.