### PR TITLE
Fix/minor bugs in online installer

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -541,6 +541,14 @@ if (('offline' -eq $InstallerType) -or ('espressif-ide' -eq $InstallerType)){
     $IsccParameters += '/DJDKARTIFACTVERSION=' + $JdkArtifactVersion
     $IsccParameters += '/DESPRESSIFIDE=yes'
     $IsccParameters += '/DOFFLINE=no'
+    
+    # Extract version from $env:VERSION (defined in CI job in format: "online-X.Y.Z")
+    # Not filled version results in string "online-"
+    $RawVersion = $env:VERSION
+    if ($RawVersion -match '^online-(.+)$') {
+        $CleanVersion = $Matches[1]
+        $IsccParameters += '/DVERSION=' + $CleanVersion
+    }
 } else {
     $IsccParameters += '/DOFFLINE=no'
 }

--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -539,8 +539,12 @@ begin
 
   Log('Installing tools:' + CmdLine);
   DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
-  CmdLine := IDFToolsPyCmd + ' install esp-clang';
-  DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
+  
+  { Only install esp-clang if the selected version does not contain 'v5.0' }
+  if (Pos('v5.0', IDFDownloadVersion) = 0) then begin
+    CmdLine := IDFToolsPyCmd + ' install esp-clang';
+    DoCmdlineInstall(CustomMessage('InstallingEspIdfTools'), '', CmdLine);
+  end;
 
   PythonVirtualEnvPath := ExpandConstant('{app}\python_env\')  + GetIDFPythonEnvironmentVersion() + '_env';
   CmdLine := PythonExecutablePath + ' -m venv "' + PythonVirtualEnvPath + '"';

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -319,11 +319,11 @@ Name: "{#COMPONENT_TARGET_ESP32_C3}"; Description: {cm:ComponentTargetEsp32c3}; 
 
 #ifndef DISABLE_TARGET_ESP32_C6
 Name: "{#COMPONENT_TARGET_ESP32_C6}"; Description: {cm:ComponentTargetEsp32c6}; Types: full; Flags: checkablealone
-Name: "{#COMPONENT_TARGET_ESP32_H}"; Description: {cm:ComponentTargetEsp32h}; Types: full; Flags: checkablealone
+Name: "{#COMPONENT_TARGET_ESP32_H}"; Description: {cm:ComponentTargetEsp32h}; Types: full;
 Name: "{#COMPONENT_TARGET_ESP32_H2}"; Description: {cm:ComponentTargetEsp32h2}; Types: custom; Flags: checkablealone
 #endif
 
-Name: "{#COMPONENT_TARGET_ESP32_S}"; Description: {cm:ComponentTargetEsp32s}; Types: full; Flags: checkablealone
+Name: "{#COMPONENT_TARGET_ESP32_S}"; Description: {cm:ComponentTargetEsp32s}; Types: full;
 Name: "{#COMPONENT_TARGET_ESP32_S2}"; Description: {cm:ComponentTargetEsp32s2}; Types: full; Flags: checkablealone
 
 #ifndef DISABLE_TARGET_ESP32_S3
@@ -331,7 +331,7 @@ Name: "{#COMPONENT_TARGET_ESP32_S3}"; Description: {cm:ComponentTargetEsp32s3}; 
 #endif
 
 #ifndef DISABLE_TARGET_ESP32_P4
-Name: "{#COMPONENT_TARGET_ESP32_P}"; Description: {cm:ComponentTargetEsp32p}; Types: full; Flags: checkablealone
+Name: "{#COMPONENT_TARGET_ESP32_P}"; Description: {cm:ComponentTargetEsp32p}; Types: full;
 
 Name: "{#COMPONENT_TARGET_ESP32_P4}"; Description: {cm:ComponentTargetEsp32p4}; Types: full; Flags: checkablealone
 #endif

--- a/src/InnoSetup/IdfToolsSetup.iss
+++ b/src/InnoSetup/IdfToolsSetup.iss
@@ -14,7 +14,7 @@
 #ifdef VERSION
 #define MyAppVersion VERSION
 #else
-#define MyAppVersion "2.3.1"
+#define MyAppVersion "2.3.4"
 #endif
 
 #define MyAppPublisher "Espressif Systems (Shanghai) Co. Ltd."


### PR DESCRIPTION
Until now the online installer version field defined in
CI 'Run workflow' button was used only to name the resulting release.

Now the version should be propagated also into InnoSetup that builds the
installer. (version in properties)
Fixes: https://github.com/espressif/idf-installer/issues/316

## Changes made
- propagate installer version to `.exe` file properties
- disable esp-clang installation for ESP-IDF v5.0 (not supported)
- Fix clickable options for series when selecting targets to install