### PR TITLE
Update: Apply git reset and submodule update for both online and offline installers

### DIFF
--- a/src/InnoSetup/Environment.iss
+++ b/src/InnoSetup/Environment.iss
@@ -198,7 +198,7 @@ begin
 end;
 
 {
-  Initialize submodules - required to call when switching branches in existing repo.
+  Initialize submodules
   E.g. created by offline installer
 }
 procedure GitUpdateSubmodules(Path: String);
@@ -287,6 +287,9 @@ begin
   DoCmdlineInstall(CustomMessage('UpdatingSubmodules'), CustomMessage('UpdatingSubmodules'), Command);
 end;
 
+{
+  Note: This procedure is not invoked for offline installer
+}
 procedure IDFDownloadInstall();
 var
   CmdLine: String;
@@ -399,9 +402,6 @@ begin
 
     CmdLine := ExpandConstant('cmd.exe /c ""xcopy.exe" /s /e /i /h /q "' + IDFTempPath + '" "' + IDFPath + '""');
     DoCmdlineInstall(CustomMessage('ExtractingEspIdf'), CustomMessage('CopyingEspIdf'), CmdLine);
-
-    GitRepoFixFileMode(IDFPath);
-    GitResetHard(IDFPath);
 
     DelTree(IDFTempPath, True, True, True);
   end;

--- a/src/InnoSetup/PostInstall.iss
+++ b/src/InnoSetup/PostInstall.iss
@@ -238,6 +238,9 @@ begin
         end;
       end;
 
+      GitRepoFixFileMode(IDFDownloadPath);
+      GitResetHard(IDFDownloadPath);
+      GitUpdateSubmodules(IDFDownloadPath);
       IDFToolsSetup();
       SaveIdfConfiguration(ExpandConstant('{app}\esp_idf.json'));
     end;


### PR DESCRIPTION
Ensure consistency of the git repository state for both online and offline installers by extending the existing git reset logic.

Previously, `GitRepoFixFileMode` and `GitResetHard` (with the defined `GitUpdateSubmodules` function never used) were only invoked when the IDF was downloaded/cloned (online installer).

This change ensures that the same reset and submodule update steps are also executed when the IDF is unzipped from an archive (offline installer).

## Changes
- Activated the existing `GitUpdateSubmodules` function (previously defined but unused).
- Moved invocation of `GitRepoFixFileMode`, `GitResetHard`, and `GitUpdateSubmodules` to be common for both install options.

## Tested
- Verified with locally built online and offline installers for v5.4.1.
- After install, idf.py --version did not report a dirty.
- Installation time remained similar to before this change (approx. +10–20 seconds).

## Related
Fixes https://github.com/espressif/esp-idf/issues/15754
