### PR TITLE
feat: Set `--depth 1` option when clonning esp-idf

### DIFF
--- a/Build-Installer.ps1
+++ b/Build-Installer.ps1
@@ -313,7 +313,7 @@ function PrepareOfflineBranches {
         git -C "$BundleDir" fetch
     } else {
         "Performing full clone."
-        git clone --branch "$OfflineBranch" -q --single-branch --shallow-submodules --recursive https://github.com/espressif/esp-idf.git "$BundleDir"
+        git clone --branch "$OfflineBranch" --depth 1 -q --single-branch --shallow-submodules --recursive https://github.com/espressif/esp-idf.git "$BundleDir"
 
         # Remove hidden attribute from .git. Inno Setup is not able to read it.
         attrib "$BundleDir\.git" -s -h


### PR DESCRIPTION
Set `--depth 1` option when cloning ESP-IDF, for offline installers, to reduce the installer size.

Tested the build locally and in [private repository](https://github.com/mfialaf/idf-installer/actions/runs/15253968352/job/42897091700) - job failed because of signing not compiling, the log says:
```
Successful compile (1593.062 sec). Resulting Setup program filename is:
2025-05-26T13:00:00.4185793Z P:\build\espressif-ide-setup-espressif-ide-with-esp-idf-5.4.1-unsigned.exe
```
